### PR TITLE
fix(TM-8401): render ddd/dddd weekday tokens in title date masks

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,19 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+	testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)+(spec|test).ts'],
+	transform: {
+		'^.+\\.tsx?$': [
+			'ts-jest',
+			{
+				tsconfig: {
+					target: 'ES2020',
+					module: 'CommonJS',
+					lib: ['ES2021', 'DOM'],
+					esModuleInterop: true,
+				},
+			},
+		],
+	},
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
-	preset: 'ts-jest',
-	testEnvironment: 'node',
-};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"dev": "vite",
 		"build": "vite build",
 		"preview": "vite preview",
-		"test": "jest --verbose ./tests",
+		"test": "jest --verbose",
 		"format": "prettier .  --write"
 	},
 	"dependencies": {

--- a/src/utils/__tests__/titlePatternHandler.test.ts
+++ b/src/utils/__tests__/titlePatternHandler.test.ts
@@ -1,0 +1,49 @@
+import { titlePatternHandler } from '../titlePatternHandler';
+
+describe('titlePatternHandler date masks', () => {
+	const FIXED = new Date(2026, 1, 19, 13, 5, 7); // Thu 2026-02-19 13:05:07
+	let nowSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		nowSpy = jest
+			.spyOn(global, 'Date')
+			.mockImplementation((...args: unknown[]) =>
+				args.length
+					? new (Date as unknown as new (...a: unknown[]) => Date)(...args)
+					: FIXED,
+			) as unknown as jest.SpyInstance;
+	});
+
+	afterEach(() => {
+		nowSpy.mockRestore();
+	});
+
+	it('renders ddd as the abbreviated weekday, not a padded day number', () => {
+		expect(titlePatternHandler('{dts#dd.mm.yyyy ddd#dte}')).toBe(
+			'19.02.2026 Thu',
+		);
+	});
+
+	it('renders dddd as the full weekday name', () => {
+		expect(titlePatternHandler('{dts#dddd#dte}')).toBe('Thursday');
+	});
+
+	it('still renders dd as the zero-padded day of month', () => {
+		expect(titlePatternHandler('{dts#dd.mm.yyyy#dte}')).toBe('19.02.2026');
+	});
+
+	it('renders time tokens correctly alongside date tokens', () => {
+		expect(titlePatternHandler('{dts#yyyy-mm-dd hh:ii:ss#dte}')).toBe(
+			'2026-02-19 13:05:07',
+		);
+	});
+
+	it('substitutes index placeholders', () => {
+		expect(
+			titlePatternHandler(
+				'task {index#category}',
+				new Map([['category', 3]]),
+			),
+		).toBe('task 3');
+	});
+});

--- a/src/utils/titlePatternHandler.ts
+++ b/src/utils/titlePatternHandler.ts
@@ -4,6 +4,8 @@ const formatMappings: Record<string, string> = {
 	'yyyy': 'yyyy',
 	'yy': 'yy',
 	'mm': 'MM',
+	'dddd': 'EEEE',
+	'ddd': 'EEE',
 	'dd': 'dd',
 	'hh': 'HH',
 	'h': 'H',


### PR DESCRIPTION
## TM-8401 — date-mask weekday tokens

### Problem
Title patterns using `{dts#...ddd#dte}` rendered `ddd` as a zero-padded day number (e.g. `019`) instead of the abbreviated weekday name, because `convertFormat()` had no mapping for `ddd`/`dddd` and `dd` was matching first.

### Fix
`src/utils/titlePatternHandler.ts` — add ordered mappings `dddd`→`EEEE` and `ddd`→`EEE` **before** `dd` in `formatMappings`:
- `ddd` → `Thu`
- `dddd` → `Thursday`
- `dd` → `19` (unchanged, zero-padded day)

### Test enablement (was needed to verify — `npm test` was red on master)
`npm test` pointed at a non-existent `./tests` dir and jest could not load its config:
- rename `jest.config.js` → `jest.config.cjs` (it uses `module.exports` but the package is `"type":"module"`)
- give ts-jest an inline `lib:["ES2021"]` tsconfig so `String.prototype.replaceAll` resolves (root `tsconfig.json` only holds project references)
- scope `testMatch` to TS specs — the ts-jest preset has no Vue SFC/babel transform
- point `npm test` at jest's default discovery

### Tests
5 new unit tests in `src/utils/__tests__/titlePatternHandler.test.ts` cover `ddd`, `dddd`, `dd`, combined time tokens, and index placeholders.

```
Test Suites: 2 passed, 2 total
Tests:       25 passed, 25 total
```
Build: `npm run build` ✓ green.

### Out of scope (flagged separately)
`src/components/Index/Index.spec.js` is a pre-existing broken Vue SFC test (no vue-jest/babel transform configured) that was never run by the old `./tests` script. Excluded by the TS-only `testMatch`; needs its own Vue test toolchain — recommend a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)