### PR TITLE
feat(TM-151): hint to configure category when GitHub repo / Cursor agent is unset

### DIFF
--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -756,6 +756,8 @@
 			getCategoryGitHubStatus(categoryId),
 			getCursorStatus(categoryId),
 		]);
+		// Ignore stale responses if the category changed while this load was in flight.
+		if (form.value.project_category_id !== categoryId) return;
 		if (github.status === 'fulfilled') {
 			categoryHasRepository.value = !!github.value.repository;
 			categoryGitHubLoaded.value = true;

--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -92,8 +92,12 @@
 		createComment,
 		createAskingHelpComment,
 	} from '@/actions/tmgr/comments';
-	import { getTaskGitActivity } from '@/actions/tmgr/github';
-	import { getCursorAgents, sendFollowUp } from '@/actions/tmgr/cursor';
+	import { getTaskGitActivity, getCategoryGitHubStatus } from '@/actions/tmgr/github';
+	import { getCursorAgents, sendFollowUp, getCursorStatus } from '@/actions/tmgr/cursor';
+	import {
+		getCategoryIntegrationHint,
+		type CategoryIntegrationHint,
+	} from '@/utils/categoryIntegrationHint';
 	import { Send, Sparkles, Bot } from 'lucide-vue-next';
 	import TaskTimeInfo from '@/components/tasks/TaskTimeInfo.vue';
 
@@ -283,6 +287,10 @@
 	const gitActivityCount = ref(0);
 	const showCursorAgentModal = ref(false);
 	const cursorAgents = ref([]);
+	const categoryHasRepository = ref(false);
+	const categoryCursorConfigured = ref(false);
+	const categoryIntegrationLoaded = ref(false);
+	const integrationHint = ref<CategoryIntegrationHint | null>(null);
 	const pomodoroBlockRef = ref<any>(null);
 	const pomodoroEnabled = computed(() => !!pomodoroBlockRef.value?.state);
 	const pomodoroBusy = computed(
@@ -591,6 +599,7 @@
 
 				await loadGitActivity();
 				await loadCursorAgents();
+				await loadCategoryIntegrationState();
 
 				nextTick(() => {
 					autoResizeTitle();
@@ -735,6 +744,61 @@
 			console.error('[Cursor] Failed to load agents:', e);
 			cursorAgents.value = [];
 		}
+	};
+
+	const loadCategoryIntegrationState = async () => {
+		const categoryId = form.value.project_category_id;
+		if (!categoryId) {
+			categoryIntegrationLoaded.value = false;
+			return;
+		}
+		const [github, cursor] = await Promise.allSettled([
+			getCategoryGitHubStatus(categoryId),
+			getCursorStatus(categoryId),
+		]);
+		categoryHasRepository.value =
+			github.status === 'fulfilled' ? !!github.value.repository : false;
+		categoryCursorConfigured.value =
+			cursor.status === 'fulfilled' ? !!cursor.value.configured : false;
+		categoryIntegrationLoaded.value =
+			github.status === 'fulfilled' || cursor.status === 'fulfilled';
+	};
+
+	const integrationState = () => ({
+		hasRepository: categoryHasRepository.value,
+		cursorConfigured: categoryCursorConfigured.value,
+	});
+
+	const openCursorAgent = () => {
+		const hint = getCategoryIntegrationHint('cursor', integrationState());
+		if (categoryIntegrationLoaded.value && hint.show) {
+			integrationHint.value = hint;
+			return;
+		}
+		showCursorAgentModal.value = true;
+	};
+
+	const openGitActivity = () => {
+		const hint = getCategoryIntegrationHint('github', integrationState());
+		if (categoryIntegrationLoaded.value && hint.show) {
+			integrationHint.value = hint;
+			return;
+		}
+		showGitActivityModal.value = true;
+	};
+
+	const goToCategorySettings = () => {
+		const categoryId = form.value.project_category_id;
+		const workspaceCode = store.getters.currentWorkspace?.code;
+		integrationHint.value = null;
+		if (!categoryId || !workspaceCode) return;
+		if (props.isModal) {
+			store.commit('closeTaskModal');
+		}
+		router.push({
+			name: 'WorkspaceCategoryEdit',
+			params: { workspace_code: workspaceCode, id: categoryId },
+		});
 	};
 
 	const sendToCursor = async () => {
@@ -1197,6 +1261,7 @@
 
 				await loadGitActivity();
 				await loadCursorAgents();
+				await loadCategoryIntegrationState();
 			} catch (e: any) {
 				console.error('Error loading linked task:', e);
 			}
@@ -1399,7 +1464,7 @@
 						<button
 							v-if="canRunWithCursor"
 							type="button"
-							@click="showCursorAgentModal = true"
+							@click="openCursorAgent"
 							class="relative flex h-7 items-center justify-center rounded-pill bg-purple-500/80 px-2 text-xs text-white hover:bg-purple-500 dark:bg-purple-600/70 dark:hover:bg-purple-600/90"
 							title="Run with Cursor Agent"
 						>
@@ -1555,7 +1620,7 @@
 							<div class="min-w-0">
 								<button
 									type="button"
-									@click="showGitActivityModal = true"
+									@click="openGitActivity"
 									class="inline-flex h-7 items-center gap-1 rounded-pill bg-surface px-2.5 text-xs font-medium text-ink hover:bg-surface-hover border border-line"
 								>
 									<CodeBracketIcon class="h-3.5 w-3.5" />
@@ -1642,7 +1707,7 @@
 						<button
 							v-if="form.id"
 							type="button"
-							@click="showGitActivityModal = true"
+							@click="openGitActivity"
 							class="relative flex items-center justify-center rounded bg-violet-500/80 px-2 py-1.5 text-xs text-white hover:bg-violet-500 dark:bg-violet-600/70 dark:hover:bg-violet-600/90"
 							title="Git Activity"
 						>
@@ -2110,6 +2175,36 @@
 					@stopped="loadCursorAgents"
 					@followup-sent="taskCommentsRef?.loadComments()"
 				/>
+			</DialogContent>
+		</Dialog>
+
+		<Dialog
+			:open="!!integrationHint"
+			@update:open="(value) => { if (!value) integrationHint = null; }"
+		>
+			<DialogContent class="max-w-md rounded-card border border-line bg-surface text-ink">
+				<DialogHeader>
+					<DialogTitle class="text-ink">{{ integrationHint?.title }}</DialogTitle>
+					<DialogDescription class="text-ink-subtle">
+						{{ integrationHint?.message }}
+					</DialogDescription>
+				</DialogHeader>
+				<div class="mt-4 flex flex-wrap justify-end gap-2">
+					<button
+						type="button"
+						class="h-9 rounded-pill border border-line bg-surface px-4 text-sm font-medium text-ink hover:bg-surface-hover"
+						@click="integrationHint = null"
+					>
+						Not now
+					</button>
+					<button
+						type="button"
+						class="h-9 rounded-pill bg-brand px-4 text-sm font-semibold text-white shadow-tmgr-xs transition-opacity hover:opacity-90"
+						@click="goToCategorySettings"
+					>
+						{{ integrationHint?.ctaLabel }}
+					</button>
+				</div>
 			</DialogContent>
 		</Dialog>
 	</div>

--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -289,7 +289,8 @@
 	const cursorAgents = ref([]);
 	const categoryHasRepository = ref(false);
 	const categoryCursorConfigured = ref(false);
-	const categoryIntegrationLoaded = ref(false);
+	const categoryGitHubLoaded = ref(false);
+	const categoryCursorLoaded = ref(false);
 	const integrationHint = ref<CategoryIntegrationHint | null>(null);
 	const pomodoroBlockRef = ref<any>(null);
 	const pomodoroEnabled = computed(() => !!pomodoroBlockRef.value?.state);
@@ -748,20 +749,21 @@
 
 	const loadCategoryIntegrationState = async () => {
 		const categoryId = form.value.project_category_id;
-		if (!categoryId) {
-			categoryIntegrationLoaded.value = false;
-			return;
-		}
+		categoryGitHubLoaded.value = false;
+		categoryCursorLoaded.value = false;
+		if (!categoryId) return;
 		const [github, cursor] = await Promise.allSettled([
 			getCategoryGitHubStatus(categoryId),
 			getCursorStatus(categoryId),
 		]);
-		categoryHasRepository.value =
-			github.status === 'fulfilled' ? !!github.value.repository : false;
-		categoryCursorConfigured.value =
-			cursor.status === 'fulfilled' ? !!cursor.value.configured : false;
-		categoryIntegrationLoaded.value =
-			github.status === 'fulfilled' || cursor.status === 'fulfilled';
+		if (github.status === 'fulfilled') {
+			categoryHasRepository.value = !!github.value.repository;
+			categoryGitHubLoaded.value = true;
+		}
+		if (cursor.status === 'fulfilled') {
+			categoryCursorConfigured.value = !!cursor.value.configured;
+			categoryCursorLoaded.value = true;
+		}
 	};
 
 	const integrationState = () => ({
@@ -771,7 +773,7 @@
 
 	const openCursorAgent = () => {
 		const hint = getCategoryIntegrationHint('cursor', integrationState());
-		if (categoryIntegrationLoaded.value && hint.show) {
+		if (categoryCursorLoaded.value && hint.show) {
 			integrationHint.value = hint;
 			return;
 		}
@@ -780,7 +782,7 @@
 
 	const openGitActivity = () => {
 		const hint = getCategoryIntegrationHint('github', integrationState());
-		if (categoryIntegrationLoaded.value && hint.show) {
+		if (categoryGitHubLoaded.value && hint.show) {
 			integrationHint.value = hint;
 			return;
 		}

--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -766,6 +766,15 @@
 		}
 	};
 
+	// Reload integration status when the category changes so the hint reflects the
+	// currently selected category, not the one loaded at open time.
+	watch(
+		() => form.value.project_category_id,
+		() => {
+			loadCategoryIntegrationState();
+		},
+	);
+
 	const integrationState = () => ({
 		hasRepository: categoryHasRepository.value,
 		cursorConfigured: categoryCursorConfigured.value,

--- a/src/utils/__tests__/categoryIntegrationHint.test.ts
+++ b/src/utils/__tests__/categoryIntegrationHint.test.ts
@@ -1,0 +1,75 @@
+import {
+	getCategoryIntegrationHint,
+	isCategoryIntegrationConfigured,
+} from '../categoryIntegrationHint';
+
+describe('isCategoryIntegrationConfigured', () => {
+	it('treats github as configured only when a repository is linked', () => {
+		expect(
+			isCategoryIntegrationConfigured('github', {
+				hasRepository: true,
+				cursorConfigured: false,
+			}),
+		).toBe(true);
+		expect(
+			isCategoryIntegrationConfigured('github', {
+				hasRepository: false,
+				cursorConfigured: true,
+			}),
+		).toBe(false);
+	});
+
+	it('treats cursor as configured only when cursor is configured', () => {
+		expect(
+			isCategoryIntegrationConfigured('cursor', {
+				hasRepository: true,
+				cursorConfigured: true,
+			}),
+		).toBe(true);
+		expect(
+			isCategoryIntegrationConfigured('cursor', {
+				hasRepository: true,
+				cursorConfigured: false,
+			}),
+		).toBe(false);
+	});
+});
+
+describe('getCategoryIntegrationHint', () => {
+	it('shows a hint when no GitHub repository is linked', () => {
+		const hint = getCategoryIntegrationHint('github', {
+			hasRepository: false,
+			cursorConfigured: false,
+		});
+		expect(hint.show).toBe(true);
+		expect(hint.kind).toBe('github');
+		expect(hint.title).toMatch(/GitHub/i);
+		expect(hint.ctaLabel).toBeTruthy();
+	});
+
+	it('shows a hint when no Cursor agent is configured', () => {
+		const hint = getCategoryIntegrationHint('cursor', {
+			hasRepository: true,
+			cursorConfigured: false,
+		});
+		expect(hint.show).toBe(true);
+		expect(hint.kind).toBe('cursor');
+		expect(hint.title).toMatch(/Cursor/i);
+	});
+
+	it('does NOT show a hint when the GitHub repository is linked', () => {
+		const hint = getCategoryIntegrationHint('github', {
+			hasRepository: true,
+			cursorConfigured: false,
+		});
+		expect(hint.show).toBe(false);
+	});
+
+	it('does NOT show a hint when Cursor is configured', () => {
+		const hint = getCategoryIntegrationHint('cursor', {
+			hasRepository: false,
+			cursorConfigured: true,
+		});
+		expect(hint.show).toBe(false);
+	});
+});

--- a/src/utils/categoryIntegrationHint.ts
+++ b/src/utils/categoryIntegrationHint.ts
@@ -1,0 +1,53 @@
+export type CategoryIntegrationKind = 'github' | 'cursor';
+
+export interface CategoryIntegrationState {
+	hasRepository: boolean;
+	cursorConfigured: boolean;
+}
+
+export interface CategoryIntegrationHint {
+	show: boolean;
+	kind: CategoryIntegrationKind;
+	title: string;
+	message: string;
+	ctaLabel: string;
+}
+
+export const isCategoryIntegrationConfigured = (
+	kind: CategoryIntegrationKind,
+	state: CategoryIntegrationState,
+): boolean =>
+	kind === 'github' ? !!state.hasRepository : !!state.cursorConfigured;
+
+const HINT_COPY: Record<
+	CategoryIntegrationKind,
+	{ title: string; message: string; ctaLabel: string }
+> = {
+	github: {
+		title: 'No GitHub repository linked',
+		message:
+			'This category has no GitHub repository linked yet. Connect one in the category settings to track commits, branches and pull requests for its tasks.',
+		ctaLabel: 'Open category settings',
+	},
+	cursor: {
+		title: 'No Cursor agent configured',
+		message:
+			'This category has no Cursor agent configured yet. Add a Cursor API key in the category settings to launch agents on its tasks.',
+		ctaLabel: 'Open category settings',
+	},
+};
+
+export const getCategoryIntegrationHint = (
+	kind: CategoryIntegrationKind,
+	state: CategoryIntegrationState,
+): CategoryIntegrationHint => {
+	const configured = isCategoryIntegrationConfigured(kind, state);
+	const copy = HINT_COPY[kind];
+	return {
+		show: !configured,
+		kind,
+		title: copy.title,
+		message: copy.message,
+		ctaLabel: copy.ctaLabel,
+	};
+};


### PR DESCRIPTION
## TM-151 — empty-state hint for unconfigured category integrations (tmgr #8335)

When a task's category has **no GitHub repository linked** or **no Cursor agent configured**, clicking the **Git activity** / **Cursor agent** buttons now opens an explanatory dialog with a CTA that takes the user straight to the **category settings**, instead of opening a feature that can't work yet.

### Behaviour
- **No repo linked** → click *Git activity* → hint + "Open category settings".
- **No Cursor agent configured** → click *Cursor agent* → hint + "Open category settings".
- **Configured** (repo linked / cursor configured) → unchanged: the feature opens as before.
- **Status unknown / not yet loaded** → falls back to the old behaviour (never blocks the user with a false hint).
- CTA routes to `WorkspaceCategoryEdit` (the category form already renders both GitHub & Cursor settings); closes the task modal first when in modal mode.

### Where the logic lives (unit-tested)
`src/utils/categoryIntegrationHint.ts` — pure helpers:
- `isCategoryIntegrationConfigured(kind, state)`
- `getCategoryIntegrationHint(kind, state)` → `{ show, kind, title, message, ctaLabel }`

`NewForm.vue` loads category GitHub status (`getCategoryGitHubStatus`) + Cursor status (`getCursorStatus`) after task load, and `openCursorAgent()` / `openGitActivity()` consult the helper before opening the modal.

### Tests / build
- 6 new unit tests for the show-logic.
- `npm run build` ✓ green.
- ⚠️ **Per PM instruction, this PR does NOT touch `jest.config`/`package.json`** (unmerged stack #165/#166/#167). Because `npm test` is still broken on `master`, the new tests were verified with an **out-of-tree** jest config (not committed): **6/6 pass** (26/26 across discovered suites). They will run under `npm test` automatically once the jest-enablement from #165–#167 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)