### PR TITLE
fix(TM-148): align task-status cache key with its invalidation pattern (tmgr #8827)

### DIFF
--- a/src/actions/tmgr/tasks.ts
+++ b/src/actions/tmgr/tasks.ts
@@ -11,11 +11,13 @@ export interface Task {
 	id: number | undefined;
 	approximately_time: number;
 	assignees: Record<string, any>[] | number[];
-	category: number | {
-		id: number;
-		title: string;
-		code: string;
-	};
+	category:
+		| number
+		| {
+				id: number;
+				title: string;
+				code: string;
+		  };
 	title: string;
 	status: string;
 	description: string | null;
@@ -80,13 +82,16 @@ interface GetTasksParams extends AxiosRequestConfig {
 	};
 }
 
-export const getTasks = async (params: GetTasksParams, current = true): Promise<PaginatedResponse<Task>> => {
+export const getTasks = async (
+	params: GetTasksParams,
+	current = true,
+): Promise<PaginatedResponse<Task>> => {
 	const { data } = await $axios.get(`tasks/${current ? 'current' : ''}`, {
 		params: {
 			page: params.page,
 			per_page: params.per_page,
-			...params.params
-		}
+			...params.params,
+		},
 	});
 
 	return data;
@@ -104,9 +109,12 @@ export const getTasksIndexes = async (categoryId: null | number = null) => {
 	return index;
 };
 
-export const getTask = async (taskId: number, useCache: boolean = false): Promise<Task> => {
+export const getTask = async (
+	taskId: number,
+	useCache: boolean = false,
+): Promise<Task> => {
 	const cacheKey = `task-${taskId}`;
-	
+
 	if (useCache) {
 		const cached = requestCache.get<Task>(cacheKey);
 		if (cached) {
@@ -146,8 +154,14 @@ export const optimizeWithAI = async (text: string) => {
 	return data;
 };
 
-export const updateTask = async (taskId: number, task: Task, sourceInstanceId?: string) => {
-	const config = sourceInstanceId ? { headers: { 'X-Source-Instance-Id': sourceInstanceId } } : {};
+export const updateTask = async (
+	taskId: number,
+	task: Task,
+	sourceInstanceId?: string,
+) => {
+	const config = sourceInstanceId
+		? { headers: { 'X-Source-Instance-Id': sourceInstanceId } }
+		: {};
 	const {
 		data: { data },
 	} = await $axios.put(`tasks/${taskId}`, task, config);
@@ -201,14 +215,14 @@ export const restoreDeletedTask = async (taskId: number) => {
 
 export const getTasksByStatus = async (
 	statusId: number,
-	params: GetTasksParams
+	params: GetTasksParams,
 ): Promise<PaginatedResponse<Task>> => {
 	const { data } = await $axios.get(`tasks/status/${statusId}`, {
 		params: {
 			page: params.page,
 			per_page: params.per_page,
-			...params.params
-		}
+			...params.params,
+		},
 	});
 
 	return data;
@@ -219,8 +233,8 @@ export const getSortedTasksByStatus = async (
 	params: AxiosRequestConfig,
 	useCache: boolean = false,
 ) => {
-	const cacheKey = requestCache.generateKey(`tasks/status/${statusId}`, params);
-	
+	const cacheKey = requestCache.generateKey(`tasks-status-${statusId}`, params);
+
 	if (useCache) {
 		const cached = requestCache.get<Task[]>(cacheKey);
 		if (cached) {
@@ -256,11 +270,11 @@ export const getBatchTasksByStatuses = async (
 	params: AxiosRequestConfig = {},
 ): Promise<Record<number, Task[]>> => {
 	const results = await Promise.all(
-		statusIds.map(statusId => 
+		statusIds.map((statusId) =>
 			getSortedTasksByStatus(statusId, params, true)
-				.then(tasks => ({ statusId, tasks }))
-				.catch(() => ({ statusId, tasks: [] }))
-		)
+				.then((tasks) => ({ statusId, tasks }))
+				.catch(() => ({ statusId, tasks: [] })),
+		),
 	);
 
 	return results.reduce((acc, { statusId, tasks }) => {
@@ -351,7 +365,7 @@ type taskOrder = {
 
 export const updateTaskOrders = async (payload: { tasks: taskOrder[] }) => {
 	await $axios.put('/tasks/update-orders', payload);
-	
+
 	requestCache.invalidate(/^tasks-status-/);
 };
 

--- a/src/utils/__tests__/taskStatusCacheInvalidation.test.ts
+++ b/src/utils/__tests__/taskStatusCacheInvalidation.test.ts
@@ -1,0 +1,39 @@
+import { requestCache } from '../requestCache';
+
+// TM-148 follow-up (tmgr #8827): getSortedTasksByStatus cached under a
+// `tasks/status/<id>` (slash) key, but every mutating task action invalidates
+// with /^tasks-status-/ (hyphen). The pattern could never match the key, so the
+// board cache stayed stale for up to 30s after a mutation. The fix aligns the
+// cache key to the `tasks-status-` namespace the invalidations already use.
+describe('task-status cache key / invalidation alignment', () => {
+	const params = { params: { all: true }, page: 1 };
+
+	beforeEach(() => requestCache.clear());
+	afterEach(() => requestCache.clear());
+
+	it('clears the tasks-status cache via the mutation pattern /^tasks-status-/', () => {
+		const key = requestCache.generateKey('tasks-status-5', params);
+		requestCache.set(key, [{ id: 1 }], 30000);
+		expect(requestCache.has(key)).toBe(true);
+
+		requestCache.invalidate(/^tasks-status-/);
+
+		expect(requestCache.has(key)).toBe(false);
+	});
+
+	it('regression: the legacy slash key was never matched by /^tasks-status-/', () => {
+		const legacyKey = requestCache.generateKey('tasks/status/5', params);
+		requestCache.set(legacyKey, [{ id: 1 }], 30000);
+
+		requestCache.invalidate(/^tasks-status-/);
+
+		// The legacy key starts with "tasks/status/", so the hyphen pattern could
+		// not match it — exactly the stale-cache bug this fix removes.
+		expect(requestCache.has(legacyKey)).toBe(true);
+	});
+
+	it('the generated key lives in the tasks-status- namespace the invalidations target', () => {
+		const key = requestCache.generateKey('tasks-status-5', params);
+		expect(/^tasks-status-/.test(key)).toBe(true);
+	});
+});


### PR DESCRIPTION
## TM-148 follow-up (tmgr #8827) — fix stale board cache

`getSortedTasksByStatus` cached under `requestCache.generateKey(\`tasks/status/\${id}\`)` (**slash**), but every mutating task action (`createTask`, `updateTask`, `updateTaskPartially`, `deleteTask`, `restoreDeletedTask`, `updateTaskStatus`, `updateTaskOrders`) invalidates with `/^tasks-status-/` (**hyphen**). The pattern could never match the key, so board results cached via `getBatchTasksByStatuses` (`useCache=true`, 30s TTL) stayed **stale for up to ~30s** after a create/update/delete/reorder. Pre-existing; surfaced during the TM-148 review (PR #169).

### Fix
One line: generate the cache key in the `tasks-status-` namespace the 8 invalidation sites already use (the HTTP URL stays `tasks/status/...`). 

### Tests
`src/utils/__tests__/taskStatusCacheInvalidation.test.ts` — 3 regression tests: the pattern now clears the key; the legacy slash key was provably never matched; the namespace assertion.

- jest (inline `--config`, **jest.config untouched** per the unmerged stack): 3/3 ✓
- `vue-tsc --noEmit` 0 · `npm run build` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)