### PR TITLE
feat(TM-8281): hours+minutes overtime in lists + status-column tooltip

### DIFF
--- a/src/components/tasks/TasksListComponent.vue
+++ b/src/components/tasks/TasksListComponent.vue
@@ -198,6 +198,11 @@
 						<span
 							class="text-sm text-ink"
 							:class="taskTimeExceeded[task.id] && 'text-status-fix-fg'"
+							:title="
+								taskOvertimes[task.id]
+									? `+${taskOvertimes[task.id]} overtime`
+									: undefined
+							"
 						>
 							{{ taskFormattedTimes[task.id] }}
 						</span>
@@ -328,6 +333,7 @@
 <script lang="ts">
 	import downloadFile from '@/utils/downloadFile';
 	import { formatRelativeTime } from '@/utils/timeUtils';
+	import { formatOvertime } from '@/utils/formatOvertime';
 	import Loader from '@/components/loaders/Loader.vue';
 	import Confirm from '@/components/general/Confirm.vue';
 	import TasksListMixin from '@/mixins/TasksListMixin';
@@ -533,10 +539,10 @@
 					overtimeSeconds += actual - expected;
 				}
 			}
-			const overtimeHours = (overtimeSeconds / 3600).toFixed(1);
+			const overtimeText = formatOvertime(overtimeSeconds);
 			let text = `${tasks.length} of ${this.tasks.length} · ${totalHours}h`;
-			if (overtimeSeconds > 0) {
-				text += ` · +${overtimeHours}h overtime`;
+			if (overtimeText) {
+				text += ` · +${overtimeText} overtime`;
 			}
 			return text;
 		},
@@ -781,21 +787,8 @@
 				if (!approximatelyTime || approximatelyTime <= 0) {
 					return null;
 				}
-				const currentTime = task.common_time || 0;
-				const overtime = currentTime - approximatelyTime;
-				if (overtime <= 0) {
-					return null;
-				}
-				const hours = Math.floor(overtime / 3600);
-				const minutes = Math.floor((overtime % 3600) / 60);
-				const parts = [];
-				if (hours > 0) {
-					parts.push(`${hours}h`);
-				}
-				if (minutes > 0) {
-					parts.push(`${minutes}m`);
-				}
-				return parts.length > 0 ? parts.join(' ') : null;
+				const overtime = (task.common_time || 0) - approximatelyTime;
+				return formatOvertime(overtime);
 			},
 			async updateStatus(task, status, dotId = null, loadTasks = true) {
 				try {

--- a/src/utils/__tests__/formatOvertime.test.ts
+++ b/src/utils/__tests__/formatOvertime.test.ts
@@ -1,0 +1,29 @@
+import { formatOvertime } from '../formatOvertime';
+
+describe('formatOvertime', () => {
+	it('returns null for non-positive or sub-minute overtime', () => {
+		expect(formatOvertime(0)).toBeNull();
+		expect(formatOvertime(-120)).toBeNull();
+		expect(formatOvertime(30)).toBeNull(); // under a minute
+		expect(formatOvertime(NaN)).toBeNull();
+	});
+
+	it('shows sub-hour overtime as minutes (not rounded to 0h)', () => {
+		expect(formatOvertime(23 * 60)).toBe('23m');
+		expect(formatOvertime(59 * 60)).toBe('59m');
+	});
+
+	it('shows whole-hour overtime as hours only', () => {
+		expect(formatOvertime(3600)).toBe('1h');
+		expect(formatOvertime(2 * 3600)).toBe('2h');
+	});
+
+	it('shows hours and minutes together', () => {
+		expect(formatOvertime(3600 + 23 * 60)).toBe('1h 23m');
+		expect(formatOvertime(2 * 3600 + 5 * 60)).toBe('2h 5m');
+	});
+
+	it('ignores leftover seconds below a minute', () => {
+		expect(formatOvertime(3600 + 23 * 60 + 45)).toBe('1h 23m');
+	});
+});

--- a/src/utils/formatOvertime.ts
+++ b/src/utils/formatOvertime.ts
@@ -1,0 +1,23 @@
+/**
+ * Formats an overtime amount (seconds a task ran over its estimate) as a compact
+ * hours+minutes string — e.g. 4980s -> "1h 23m", 1380s -> "23m", 3600s -> "1h".
+ *
+ * Returns null when there is no meaningful overtime (<= 0, or under a minute), so callers
+ * can hide the overtime affordance entirely. Sub-hour overtime stays visible as minutes
+ * rather than being rounded to "0.0h".
+ */
+export function formatOvertime(seconds: number): string | null {
+	if (!Number.isFinite(seconds) || seconds <= 0) {
+		return null;
+	}
+	const hours = Math.floor(seconds / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	const parts: string[] = [];
+	if (hours > 0) {
+		parts.push(`${hours}h`);
+	}
+	if (minutes > 0) {
+		parts.push(`${minutes}m`);
+	}
+	return parts.length > 0 ? parts.join(' ') : null;
+}


### PR DESCRIPTION
## TM-8281 (tmgr #8281) — finish the task-overtime display in lists

Overtime display was partially implemented (`overtimeSeconds` + `· +Xh overtime` text + per-task `:overtime`). This builds the two remaining gaps **surgically**, reusing the existing time logic.

### Changes
1. **Hours + minutes granularity.** New reusable `src/utils/formatOvertime.ts` → `"1h 23m"` / `"23m"` / `"1h"` (null when `<= 0` or sub-minute). Sub-hour overtime now shows minutes instead of rounding to `0.0h`. `getTaskOvertime` refactored to reuse it (identical output, DRY), and the `selectedSummary` aggregate now renders `· +1h 23m overtime` instead of hours-only `+X.Xh`.
2. **Status-column tooltip.** The per-row time in the status column now has a `title` tooltip showing that row's overtime (`+1h 23m overtime`), shown only when the row is over estimate.

### Gates
- `formatOvertime` unit tests (sub-minute → null, sub-hour → minutes, whole-hour, combined, leftover-seconds). Full suite **25/25 green**.
- `npm run build` ✓.
- Per the constraint, the repo `jest.config`/`package.json` test-config is untouched (tests run via an equivalent inline `--config`, like the other open PRs).

Base `master`. Not merged — QA + codex to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)