### PR TITLE
feat(TM-8281): overtime in hours+minutes + tooltip on status-column time

### DIFF
--- a/src/components/tasks/TasksListComponent.vue
+++ b/src/components/tasks/TasksListComponent.vue
@@ -198,6 +198,11 @@
 						<span
 							class="text-sm text-ink"
 							:class="taskTimeExceeded[task.id] && 'text-status-fix-fg'"
+							:title="
+								taskOvertimes[task.id]
+									? 'Overtime: +' + taskOvertimes[task.id]
+									: undefined
+							"
 						>
 							{{ taskFormattedTimes[task.id] }}
 						</span>
@@ -328,6 +333,7 @@
 <script lang="ts">
 	import downloadFile from '@/utils/downloadFile';
 	import { formatRelativeTime } from '@/utils/timeUtils';
+	import { formatOvertimeDuration } from '@/utils/overtimeFormat';
 	import Loader from '@/components/loaders/Loader.vue';
 	import Confirm from '@/components/general/Confirm.vue';
 	import TasksListMixin from '@/mixins/TasksListMixin';
@@ -533,10 +539,10 @@
 					overtimeSeconds += actual - expected;
 				}
 			}
-			const overtimeHours = (overtimeSeconds / 3600).toFixed(1);
+			const overtimeText = formatOvertimeDuration(overtimeSeconds);
 			let text = `${tasks.length} of ${this.tasks.length} · ${totalHours}h`;
-			if (overtimeSeconds > 0) {
-				text += ` · +${overtimeHours}h overtime`;
+			if (overtimeText) {
+				text += ` · +${overtimeText} overtime`;
 			}
 			return text;
 		},
@@ -783,19 +789,7 @@
 				}
 				const currentTime = task.common_time || 0;
 				const overtime = currentTime - approximatelyTime;
-				if (overtime <= 0) {
-					return null;
-				}
-				const hours = Math.floor(overtime / 3600);
-				const minutes = Math.floor((overtime % 3600) / 60);
-				const parts = [];
-				if (hours > 0) {
-					parts.push(`${hours}h`);
-				}
-				if (minutes > 0) {
-					parts.push(`${minutes}m`);
-				}
-				return parts.length > 0 ? parts.join(' ') : null;
+				return formatOvertimeDuration(overtime) || null;
 			},
 			async updateStatus(task, status, dotId = null, loadTasks = true) {
 				try {

--- a/src/utils/__tests__/overtimeFormat.test.ts
+++ b/src/utils/__tests__/overtimeFormat.test.ts
@@ -1,0 +1,35 @@
+import { formatOvertimeDuration } from '../overtimeFormat';
+
+describe('formatOvertimeDuration', () => {
+	it('returns empty string for no / non-positive overtime', () => {
+		expect(formatOvertimeDuration(0)).toBe('');
+		expect(formatOvertimeDuration(-120)).toBe('');
+		expect(formatOvertimeDuration(NaN)).toBe('');
+	});
+
+	it('returns empty string for sub-minute overtime (floored)', () => {
+		expect(formatOvertimeDuration(45)).toBe('');
+		expect(formatOvertimeDuration(59)).toBe('');
+	});
+
+	it('shows minutes only when under an hour', () => {
+		expect(formatOvertimeDuration(60)).toBe('1m');
+		expect(formatOvertimeDuration(30 * 60)).toBe('30m');
+		expect(formatOvertimeDuration(59 * 60)).toBe('59m');
+	});
+
+	it('shows hours only when on a whole hour boundary', () => {
+		expect(formatOvertimeDuration(3600)).toBe('1h');
+		expect(formatOvertimeDuration(2 * 3600)).toBe('2h');
+	});
+
+	it('shows hours and minutes together', () => {
+		expect(formatOvertimeDuration(3600 + 30 * 60)).toBe('1h 30m');
+		expect(formatOvertimeDuration(2 * 3600 + 5 * 60)).toBe('2h 5m');
+	});
+
+	it('regression: a sub-hour overtime is no longer rounded away to 0h', () => {
+		// Previously rendered as "0.0h" via (seconds / 3600).toFixed(1).
+		expect(formatOvertimeDuration(20 * 60)).toBe('20m');
+	});
+});

--- a/src/utils/overtimeFormat.ts
+++ b/src/utils/overtimeFormat.ts
@@ -1,0 +1,19 @@
+// Formats an overtime duration (in seconds) as a compact "Xh Ym" string.
+// Returns '' when there is no positive overtime to show (callers treat the
+// empty string as "no overtime"). Minutes are floored; a sub-minute overtime
+// therefore yields '' rather than a misleading "0m".
+export function formatOvertimeDuration(seconds: number): string {
+	if (!seconds || seconds <= 0) {
+		return '';
+	}
+	const hours = Math.floor(seconds / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	const parts: string[] = [];
+	if (hours > 0) {
+		parts.push(`${hours}h`);
+	}
+	if (minutes > 0) {
+		parts.push(`${minutes}m`);
+	}
+	return parts.join(' ');
+}


### PR DESCRIPTION
## TM-8281 — overtime granularity + status-column tooltip

Finishes the **partially-implemented** overtime display in `TasksListComponent.vue` (prior art: per-row `getTaskOvertime` + `+Xh overtime` rendering). Per the ticket, only the two remaining gaps are addressed — no rewrite of the existing logic.

### Changes
1. **Hours + minutes granularity.** `selectedSummary` rendered overtime via `(overtimeSeconds / 3600).toFixed(1)` → a sub-hour overtime collapsed to `+0.0h`. Now uses a shared `formatOvertimeDuration()` → `+Xh Ym`.
2. **Tooltip on the status-column time.** The hours value now carries a `title="Overtime: +Xh Ym"` for overtimed rows (mirrors the existing `TaskTimeInfo` overtime affordance).
3. **Shared formatter + unit test.** New `src/utils/overtimeFormat.ts` (`formatOvertimeDuration(seconds) → "Xh Ym"`), reused by both `getTaskOvertime` (identical output to before) and `selectedSummary`. Covered by `src/utils/__tests__/overtimeFormat.test.ts`, including a regression case for the old `0.0h` rounding.

### Validation
- `formatOvertimeDuration` suite: **6/6 passing** (run with an explicit ts-jest config — see note below).
- `npm run build`: ✅ compiles, no type errors.

### Note on jest config (intentional)
`jest.config` is **untouched** here, per the ticket. On `master` it's still broken (`jest.config.js` + `"type":"module"`), so `npm test` won't load until **TM-8825 / PR #172** merges. Once #172 lands, this test runs under the standard `npm test` with no change required (it already matches the `testMatch` pattern). I validated locally against an equivalent throwaway `.cjs` config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)