### PR TITLE
fix(TM-168): board category filter wiped by router-view re-mount

### DIFF
--- a/src/pages/Board.vue
+++ b/src/pages/Board.vue
@@ -1343,10 +1343,10 @@
 						);
 					}
 				}
-				if (this.chosenCategory?.id) {
-					const chosenCategoryId = Number(this.chosenCategory.id);
+				const selectedCategoryId = Number(this.$store.state.filter.selectedCategory);
+				if (selectedCategoryId) {
 					tasks = tasks.filter(
-						(task) => Number(task.project_category_id) === chosenCategoryId,
+						(task) => Number(task.project_category_id) === selectedCategoryId,
 					);
 				}
 				return tasks;

--- a/src/pages/Board.vue
+++ b/src/pages/Board.vue
@@ -1344,8 +1344,9 @@
 					}
 				}
 				if (this.chosenCategory?.id) {
+					const chosenCategoryId = Number(this.chosenCategory.id);
 					tasks = tasks.filter(
-						(task) => task.project_category_id === this.chosenCategory.id,
+						(task) => Number(task.project_category_id) === chosenCategoryId,
 					);
 				}
 				return tasks;


### PR DESCRIPTION
## TM-168 (#8863) — kanban board category filter doesn't work

**Root cause found and fix verified on the live stage board (real Java-backend data).**

### What was actually wrong
1. The original PHP-backend diagnosis (string `project_category_id`) was wrong for the live env. **Stage/prod run the Java backend, where `project_category_id` is already an `int`** — so the strict comparison was never the problem and the earlier `Number()` change was a no-op (that's why it "didn't fix it live").
2. **Real root cause:** selecting a category calls `FiltersBoard.debouncedRouterPush`, writing `?category=…` to the URL. `App.vue` keys the `<router-view>` by **`route.fullPath`**, so the query change **re-mounts the Board fresh**, resetting the component-local `chosenCategory` to its `null` default. A second, **unfiltered** `loadTasks` then runs on mount and **overwrites** the correctly-filtered columns. Net effect: the board filters for a frame, then shows everything.

Confirmed via live instrumentation — two `loadTasks` run per selection: the first with `selectedCategory=183` (filters), the second after re-mount with `chosenCategory=null` (unfiltered, clobbers).

### Why the user filter worked but category didn't
`loadTasksByStatus` reads the **user** filter from the persisted store (`state.filter.selectedUser`), which survives the re-mount. The **category** filter relied on transient component-local `chosenCategory`, which the re-mount wipes.

### Fix
Make the category filter read from the **persisted store**, exactly like the user filter:
```js
const selectedCategoryId = Number(this.$store.state.filter.selectedCategory);
if (selectedCategoryId) {
  tasks = tasks.filter(t => Number(t.project_category_id) === selectedCategoryId);
}
```
`state.filter.selectedCategory` survives the re-mount, so both the original and the post-remount `loadTasks` filter correctly. `Number()` kept as harmless defensive normalization.

### Scope
- **Only `Board.vue`** (`loadTasksByStatus`). No overlap with the frozen queue (`TasksListPage`/`NewForm`).
- Did **not** touch `App.vue`'s `route.fullPath` key (broad/risky); the store-read fix is targeted and matches the existing user-filter pattern.

### Verification (live, stage)
Reproduced on a real board against the stage API. Before: selecting WsCat → board still shows Design/other tasks. After: selecting WsCat → column shows **only** the WsCat task; both internal loads read `selectedCategoryId=183`. `npm run build` ✓, `npm test` 94/94 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)