### PR TITLE
feat(TM-119, TM-133): task attachments via S3 presigned-URL flow

### DIFF
--- a/src/actions/tmgr/files.ts
+++ b/src/actions/tmgr/files.ts
@@ -14,7 +14,7 @@ export interface TaskFile {
 	size: number | null;
 	task_id: number;
 	user_id: number;
-	workspace_id: number;
+	workspace_id: number | null;
 	created_at: string | null;
 }
 

--- a/src/actions/tmgr/files.ts
+++ b/src/actions/tmgr/files.ts
@@ -131,8 +131,13 @@ export const deleteTaskFile = async (
 	requestCache.invalidate(`files-task-${taskId}`);
 };
 
-const fetchPresignedFile = async (filePath: string): Promise<Blob> => {
-	const url = await presignDownload(filePath);
+// Exported (not just an internal helper) so callers that need to derive more
+// than one independent object URL from the same file (e.g. a grid thumbnail
+// and, later, a preview modal for that same file) can do so from one fetch
+// instead of sharing a single URL string across two owners with different
+// lifetimes.
+export const getFileBlob = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<Blob> => {
+	const url = await presignDownload(file.filePath);
 	const response = await fetch(url);
 	if (!response.ok) {
 		throw new Error(`Presigned download failed: ${response.status}`);
@@ -142,18 +147,18 @@ const fetchPresignedFile = async (filePath: string): Promise<Blob> => {
 };
 
 export const downloadTaskFile = async (file: Pick<TaskFile, 'id' | 'filePath'>, fileName: string): Promise<void> => {
-	const blob = await fetchPresignedFile(file.filePath);
+	const blob = await getFileBlob(file);
 	downloadFile(blob, fileName);
 };
 
 export const getFilePreviewUrl = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
-	const blob = await fetchPresignedFile(file.filePath);
+	const blob = await getFileBlob(file);
 
 	return window.URL.createObjectURL(blob);
 };
 
 export const getFileTextContent = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
-	const blob = await fetchPresignedFile(file.filePath);
+	const blob = await getFileBlob(file);
 
 	return blob.text();
 };

--- a/src/actions/tmgr/files.ts
+++ b/src/actions/tmgr/files.ts
@@ -1,0 +1,163 @@
+import $axios from '@/plugins/axios';
+import { requestCache } from '@/utils/requestCache';
+
+// Task attachments are served by the Java backend's files module (S3-backed),
+// which returns camelCase fields — unlike the rest of this app's PHP-backed
+// Task interface, which is snake_case.
+export interface TaskFile {
+	id: number;
+	name: string;
+	originalName: string | null;
+	filePath: string;
+	mimeType: string | null;
+	size: number | null;
+	taskId: number;
+	userId: number;
+	workspaceId: number;
+	createdAt: string | null;
+}
+
+export const getFileType = (mimeType: string | null, fileName: string): 'image' | 'video' | 'pdf' | 'text' | 'other' => {
+	const ext = fileName.split('.').pop()?.toLowerCase() || '';
+
+	if (ext === 'pdf' || mimeType === 'application/pdf') return 'pdf';
+
+	if (mimeType) {
+		if (mimeType.startsWith('image/')) return 'image';
+		if (mimeType.startsWith('video/')) return 'video';
+		if (mimeType.startsWith('text/') || mimeType === 'application/json') return 'text';
+	}
+
+	if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp'].includes(ext)) return 'image';
+	if (['mp4', 'webm', 'ogg', 'mov', 'avi', 'mkv'].includes(ext)) return 'video';
+	if (['txt', 'md', 'json', 'js', 'ts', 'css', 'html', 'xml', 'yaml', 'yml', 'log', 'csv'].includes(ext)) return 'text';
+
+	return 'other';
+};
+
+export const isPreviewable = (mimeType: string | null, fileName: string): boolean => {
+	const type = getFileType(mimeType, fileName);
+	return type !== 'other';
+};
+
+export const getTaskFiles = async (
+	taskId: number,
+	useCache: boolean = false,
+): Promise<TaskFile[]> => {
+	const cacheKey = `files-task-${taskId}`;
+
+	if (useCache) {
+		const cached = requestCache.get<TaskFile[]>(cacheKey);
+		if (cached) {
+			return cached;
+		}
+	}
+
+	const {
+		data: { data },
+	} = await $axios.get(`/tasks/${taskId}/files`);
+
+	if (useCache) {
+		requestCache.set(cacheKey, data, 30000);
+	}
+
+	return data;
+};
+
+interface PresignedUpload {
+	key: string;
+	upload_url: string;
+	method: string;
+}
+
+const presignUpload = async (fileName: string, contentType: string): Promise<PresignedUpload> => {
+	const {
+		data: { data },
+	} = await $axios.post('/files/presign-upload', { fileName, contentType });
+
+	return data;
+};
+
+const presignDownload = async (key: string): Promise<string> => {
+	const {
+		data: { data },
+	} = await $axios.post('/files/presign-download', { key });
+
+	return data.download_url;
+};
+
+// Uploads go straight to S3 via a presigned URL, not through our backend —
+// $axios always attaches a bearer token and a 30s timeout meant for API
+// calls, neither of which belongs on a direct-to-S3 PUT of arbitrary file
+// size, so this uses a bare fetch. S3 also requires the Content-Type on the
+// PUT to match the one used to sign the URL, or the request is rejected.
+export const uploadTaskFile = async (
+	taskId: number,
+	file: File,
+): Promise<TaskFile> => {
+	const contentType = file.type || 'application/octet-stream';
+	const { key, upload_url } = await presignUpload(file.name, contentType);
+
+	const putResponse = await fetch(upload_url, {
+		method: 'PUT',
+		headers: { 'Content-Type': contentType },
+		body: file,
+	});
+	if (!putResponse.ok) {
+		throw new Error(`S3 upload failed: ${putResponse.status}`);
+	}
+
+	const {
+		data: { data },
+	} = await $axios.post(`/tasks/${taskId}/files`, {
+		fileName: file.name,
+		filePath: key,
+		mimeType: contentType,
+		sizeBytes: file.size,
+	});
+
+	requestCache.invalidate(`files-task-${taskId}`);
+
+	return data;
+};
+
+export const deleteTaskFile = async (
+	fileId: number,
+	taskId?: number,
+): Promise<void> => {
+	await $axios.delete(`/files/${fileId}`);
+
+	if (taskId) {
+		requestCache.invalidate(`files-task-${taskId}`);
+	}
+};
+
+export const downloadTaskFile = async (file: Pick<TaskFile, 'id' | 'filePath'>, fileName: string): Promise<void> => {
+	const url = await presignDownload(file.filePath);
+	const response = await fetch(url);
+	const blob = await response.blob();
+
+	const objectUrl = window.URL.createObjectURL(blob);
+	const link = document.createElement('a');
+	link.href = objectUrl;
+	link.setAttribute('download', fileName);
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	window.URL.revokeObjectURL(objectUrl);
+};
+
+export const getFilePreviewUrl = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
+	const url = await presignDownload(file.filePath);
+	const response = await fetch(url);
+	const blob = await response.blob();
+
+	return window.URL.createObjectURL(blob);
+};
+
+export const getFileTextContent = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
+	const url = await presignDownload(file.filePath);
+	const response = await fetch(url);
+
+	return response.text();
+};

--- a/src/actions/tmgr/files.ts
+++ b/src/actions/tmgr/files.ts
@@ -1,5 +1,6 @@
 import $axios from '@/plugins/axios';
 import { requestCache } from '@/utils/requestCache';
+import downloadFile from '@/utils/downloadFile';
 
 // Task attachments are served by the Java backend's files module (S3-backed),
 // which returns camelCase fields — unlike the rest of this app's PHP-backed
@@ -96,10 +97,10 @@ export const uploadTaskFile = async (
 	file: File,
 ): Promise<TaskFile> => {
 	const contentType = file.type || 'application/octet-stream';
-	const { key, upload_url } = await presignUpload(file.name, contentType);
+	const { key, upload_url, method } = await presignUpload(file.name, contentType);
 
 	const putResponse = await fetch(upload_url, {
-		method: 'PUT',
+		method,
 		headers: { 'Content-Type': contentType },
 		body: file,
 	});
@@ -123,41 +124,36 @@ export const uploadTaskFile = async (
 
 export const deleteTaskFile = async (
 	fileId: number,
-	taskId?: number,
+	taskId: number,
 ): Promise<void> => {
 	await $axios.delete(`/files/${fileId}`);
 
-	if (taskId) {
-		requestCache.invalidate(`files-task-${taskId}`);
+	requestCache.invalidate(`files-task-${taskId}`);
+};
+
+const fetchPresignedFile = async (filePath: string): Promise<Blob> => {
+	const url = await presignDownload(filePath);
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Presigned download failed: ${response.status}`);
 	}
+
+	return response.blob();
 };
 
 export const downloadTaskFile = async (file: Pick<TaskFile, 'id' | 'filePath'>, fileName: string): Promise<void> => {
-	const url = await presignDownload(file.filePath);
-	const response = await fetch(url);
-	const blob = await response.blob();
-
-	const objectUrl = window.URL.createObjectURL(blob);
-	const link = document.createElement('a');
-	link.href = objectUrl;
-	link.setAttribute('download', fileName);
-	document.body.appendChild(link);
-	link.click();
-	link.remove();
-	window.URL.revokeObjectURL(objectUrl);
+	const blob = await fetchPresignedFile(file.filePath);
+	downloadFile(blob, fileName);
 };
 
 export const getFilePreviewUrl = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
-	const url = await presignDownload(file.filePath);
-	const response = await fetch(url);
-	const blob = await response.blob();
+	const blob = await fetchPresignedFile(file.filePath);
 
 	return window.URL.createObjectURL(blob);
 };
 
 export const getFileTextContent = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
-	const url = await presignDownload(file.filePath);
-	const response = await fetch(url);
+	const blob = await fetchPresignedFile(file.filePath);
 
-	return response.text();
+	return blob.text();
 };

--- a/src/actions/tmgr/files.ts
+++ b/src/actions/tmgr/files.ts
@@ -3,19 +3,19 @@ import { requestCache } from '@/utils/requestCache';
 import downloadFile from '@/utils/downloadFile';
 
 // Task attachments are served by the Java backend's files module (S3-backed),
-// which returns camelCase fields — unlike the rest of this app's PHP-backed
-// Task interface, which is snake_case.
+// which is snake_case like the rest of the app's API, confirmed live against
+// stage — an earlier draft of this module assumed camelCase (it isn't).
 export interface TaskFile {
 	id: number;
 	name: string;
-	originalName: string | null;
-	filePath: string;
-	mimeType: string | null;
+	original_name: string | null;
+	file_path: string;
+	mime_type: string | null;
 	size: number | null;
-	taskId: number;
-	userId: number;
-	workspaceId: number;
-	createdAt: string | null;
+	task_id: number;
+	user_id: number;
+	workspace_id: number;
+	created_at: string | null;
 }
 
 export const getFileType = (mimeType: string | null, fileName: string): 'image' | 'video' | 'pdf' | 'text' | 'other' => {
@@ -74,7 +74,10 @@ interface PresignedUpload {
 const presignUpload = async (fileName: string, contentType: string): Promise<PresignedUpload> => {
 	const {
 		data: { data },
-	} = await $axios.post('/files/presign-upload', { fileName, contentType });
+	} = await $axios.post('/files/presign-upload', {
+		file_name: fileName,
+		content_type: contentType,
+	});
 
 	return data;
 };
@@ -111,10 +114,10 @@ export const uploadTaskFile = async (
 	const {
 		data: { data },
 	} = await $axios.post(`/tasks/${taskId}/files`, {
-		fileName: file.name,
-		filePath: key,
-		mimeType: contentType,
-		sizeBytes: file.size,
+		file_name: file.name,
+		file_path: key,
+		mime_type: contentType,
+		size_bytes: file.size,
 	});
 
 	requestCache.invalidate(`files-task-${taskId}`);
@@ -136,8 +139,8 @@ export const deleteTaskFile = async (
 // and, later, a preview modal for that same file) can do so from one fetch
 // instead of sharing a single URL string across two owners with different
 // lifetimes.
-export const getFileBlob = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<Blob> => {
-	const url = await presignDownload(file.filePath);
+export const getFileBlob = async (file: Pick<TaskFile, 'id' | 'file_path'>): Promise<Blob> => {
+	const url = await presignDownload(file.file_path);
 	const response = await fetch(url);
 	if (!response.ok) {
 		throw new Error(`Presigned download failed: ${response.status}`);
@@ -146,18 +149,18 @@ export const getFileBlob = async (file: Pick<TaskFile, 'id' | 'filePath'>): Prom
 	return response.blob();
 };
 
-export const downloadTaskFile = async (file: Pick<TaskFile, 'id' | 'filePath'>, fileName: string): Promise<void> => {
+export const downloadTaskFile = async (file: Pick<TaskFile, 'id' | 'file_path'>, fileName: string): Promise<void> => {
 	const blob = await getFileBlob(file);
 	downloadFile(blob, fileName);
 };
 
-export const getFilePreviewUrl = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
+export const getFilePreviewUrl = async (file: Pick<TaskFile, 'id' | 'file_path'>): Promise<string> => {
 	const blob = await getFileBlob(file);
 
 	return window.URL.createObjectURL(blob);
 };
 
-export const getFileTextContent = async (file: Pick<TaskFile, 'id' | 'filePath'>): Promise<string> => {
+export const getFileTextContent = async (file: Pick<TaskFile, 'id' | 'file_path'>): Promise<string> => {
 	const blob = await getFileBlob(file);
 
 	return blob.text();

--- a/src/components/tasks/TaskAttachments.vue
+++ b/src/components/tasks/TaskAttachments.vue
@@ -1,79 +1,109 @@
 <template>
-	<div class="task-attachments mt-4">
-		<div class="mb-3 flex items-center justify-between">
-			<h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">
-				Attachments
-			</h3>
-			<button
-				@click="handleAddFiles"
-				class="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-blue-600 transition-colors hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-gray-800"
-			>
-				<Paperclip :size="16" />
-				<span>Add files</span>
-			</button>
+	<div class="task-attachments">
+		<div v-if="isLoading" class="py-2 text-center text-2xs text-ink-subtle">
+			Loading…
 		</div>
 
-		<div v-if="files.length > 0" class="mb-3 space-y-2">
+		<!-- Grid of thumbnails -->
+		<div v-else-if="allFiles.length > 0" class="flex flex-wrap gap-2">
 			<div
-				v-for="(file, index) in files"
-				:key="index"
-				class="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 transition-colors hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
+				v-for="file in allFiles"
+				:key="file.id || file.tempId"
+				class="group relative"
 			>
-				<div class="flex-shrink-0">
-					<img
-						v-if="file.preview"
-						:src="file.preview"
-						:alt="file.name"
-						class="h-12 w-12 rounded object-cover"
-					/>
-					<FileIcon
-						v-else
-						:size="20"
-						class="text-gray-500 dark:text-gray-400"
-					/>
-				</div>
-				<div class="min-w-0 flex-1">
-					<p
-						class="truncate text-sm font-medium text-gray-900 dark:text-gray-100"
-					>
-						{{ file.name }}
-					</p>
-					<p class="text-xs text-gray-500 dark:text-gray-400">
-						{{ formatFileSize(file.size) }}
-					</p>
-				</div>
-				<button
-					@click="handleRemoveFile(index)"
-					class="flex-shrink-0 rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+				<!-- Thumbnail -->
+				<div
+					@click="openPreview(file)"
+					class="flex h-16 w-16 cursor-pointer items-center justify-center overflow-hidden rounded-card border transition-colors"
+					:class="file.uploading ? 'border-line-strong bg-surface-sunken' : 'border-line bg-surface hover:border-line-strong'"
+					:title="file.name"
 				>
-					<X :size="16" />
-				</button>
+					<!-- Image thumbnail -->
+					<img
+						v-if="file.thumbnailUrl || file.preview"
+						:src="file.thumbnailUrl || file.preview"
+						:alt="file.name"
+						class="h-full w-full object-cover"
+					/>
+					<!-- File type icon -->
+					<span
+						v-else
+						class="material-icons"
+						:class="getFileIconClass(file)"
+						style="font-size: 26px"
+						>{{ getFileIcon(file) }}</span
+					>
+					<!-- Uploading overlay -->
+					<div
+						v-if="file.uploading"
+						class="absolute inset-0 flex items-center justify-center bg-surface/60"
+					>
+						<div class="h-4 w-4 animate-spin rounded-full border-2 border-brand border-t-transparent"></div>
+					</div>
+				</div>
+
+				<!-- Actions (on hover) -->
+				<div
+					v-if="!file.uploading"
+					class="absolute -right-1 -top-1 flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+				>
+					<button
+						v-if="file.id"
+						type="button"
+						@click.stop="handleDownloadFile(file)"
+						class="flex size-5 items-center justify-center rounded-pill bg-surface shadow-sm hover:bg-surface-hover"
+						title="Download"
+					>
+						<span class="material-icons text-ink-subtle" style="font-size: 12px">download</span>
+					</button>
+					<button
+						type="button"
+						@click.stop="handleRemoveFile(file)"
+						class="flex size-5 items-center justify-center rounded-pill bg-surface shadow-sm hover:bg-surface-hover"
+						title="Remove"
+					>
+						<span class="material-icons text-status-fix-fg" style="font-size: 12px">close</span>
+					</button>
+				</div>
+
+				<!-- File name tooltip on hover -->
+				<div
+					class="pointer-events-none absolute left-1/2 top-full z-10 mt-1 hidden -translate-x-1/2 whitespace-nowrap rounded-md bg-ink px-2 py-1 text-2xs text-surface-base group-hover:block"
+				>
+					{{ truncateFileName(file.name, 20) }}
+				</div>
+			</div>
+
+			<!-- Add more button -->
+			<div
+				v-if="taskId && !isUploading"
+				@click="handleAddFiles"
+				class="flex h-16 w-16 cursor-pointer items-center justify-center rounded-card border-2 border-dashed border-line-strong text-ink-subtle transition hover:bg-surface-sunken hover:text-ink"
+				title="Add files"
+			>
+				<span class="material-icons" style="font-size: 22px">add</span>
 			</div>
 		</div>
 
-		<div
-			@click="handleAddFiles"
-			@dragover.prevent="handleDragOver"
-			@dragleave.prevent="handleDragLeave"
-			@drop.prevent="handleDrop"
-			:class="[
-				'cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition-colors',
-				isDragOver
-					? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20'
-					: 'border-gray-300 hover:border-gray-400 hover:bg-gray-50 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-800/50',
-			]"
-		>
-			<FileIcon
-				:size="32"
-				class="mx-auto mb-2 text-gray-400 dark:text-gray-500"
-			/>
-			<p class="text-sm text-gray-500 dark:text-gray-400">
-				{{ files.length === 0 ? 'No attachments yet' : 'Add more files' }}
-			</p>
-			<p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
-				Click or drag files here to attach documents, images, or other files
-			</p>
-		</div>
+		<!-- Empty state with drop zone (hidden when hideEmptyState is true) -->
+		<template v-else-if="!hideEmptyState">
+			<div class="text-2xs text-ink-subtle">No attachments yet</div>
+
+			<!-- Drop zone -->
+			<div
+				v-if="taskId"
+				@click="handleAddFiles"
+				@dragover.prevent="handleDragOver"
+				@dragleave.prevent="handleDragLeave"
+				@drop.prevent="handleDrop"
+				class="mt-2 cursor-pointer rounded-card border-2 border-dashed p-4 text-center transition-colors"
+				:class="isDragOver ? 'border-brand bg-brand-bg' : 'border-line-strong hover:bg-surface-sunken'"
+			>
+				<p class="text-2xs text-ink-subtle">
+					{{ isUploading ? 'Uploading…' : 'Click or drag files here' }}
+				</p>
+			</div>
+		</template>
 
 		<input
 			ref="fileInput"
@@ -82,39 +112,256 @@
 			class="hidden"
 			@change="handleFileSelect"
 		/>
+
+		<!-- Preview Modal -->
+		<div
+			v-if="previewFile"
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+			@click="closePreview"
+		>
+			<div
+				class="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-card border border-line bg-surface shadow-2xl"
+				@click.stop
+			>
+				<!-- Modal Header -->
+				<div class="sticky top-0 z-10 flex items-center justify-between border-b border-line bg-surface px-4 py-3">
+					<h3 class="truncate text-sm font-semibold text-ink">
+						{{ previewFile.name }}
+					</h3>
+					<div class="flex items-center gap-2">
+						<button
+							type="button"
+							@click="handleDownloadFile(previewFile)"
+							class="rounded-md p-1.5 text-ink-subtle hover:bg-surface-hover"
+							title="Download"
+						>
+							<span class="material-icons" style="font-size: 18px">download</span>
+						</button>
+						<button
+							type="button"
+							@click="closePreview"
+							class="rounded-md p-1.5 text-ink-subtle hover:bg-surface-hover"
+							title="Close"
+						>
+							<span class="material-icons" style="font-size: 18px">close</span>
+						</button>
+					</div>
+				</div>
+
+				<!-- Modal Content -->
+				<div class="p-4">
+					<!-- Loading -->
+					<div v-if="isLoadingPreview" class="flex h-64 w-96 items-center justify-center">
+						<div class="h-8 w-8 animate-spin rounded-full border-4 border-brand border-t-transparent"></div>
+					</div>
+
+					<!-- Image Preview -->
+					<img
+						v-else-if="previewType === 'image' && previewUrl"
+						:src="previewUrl"
+						:alt="previewFile.name"
+						class="max-h-[70vh] max-w-full object-contain"
+					/>
+
+					<!-- Video Preview -->
+					<video
+						v-else-if="previewType === 'video' && previewUrl"
+						:src="previewUrl"
+						controls
+						class="max-h-[70vh] max-w-full"
+					/>
+
+					<!-- PDF Preview -->
+					<iframe
+						v-else-if="previewType === 'pdf' && previewUrl"
+						:src="previewUrl"
+						class="h-[70vh] w-[800px] max-w-full"
+					/>
+
+					<!-- Text Preview -->
+					<pre
+						v-else-if="previewType === 'text' && previewContent"
+						class="max-h-[70vh] max-w-[800px] overflow-auto rounded-md bg-surface-sunken p-4 text-sm text-ink"
+					>{{ previewContent }}</pre>
+
+					<!-- Unsupported type -->
+					<div v-else class="flex h-64 w-96 flex-col items-center justify-center text-ink-subtle">
+						<span class="material-icons mb-4" style="font-size: 48px">insert_drive_file</span>
+						<p class="text-sm">Preview not available for this file type</p>
+						<button
+							type="button"
+							@click="handleDownloadFile(previewFile)"
+							class="mt-4 rounded-pill bg-brand px-4 py-2 text-sm font-semibold text-white hover:bg-brand-hover"
+						>
+							Download file
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 </template>
 
 <script>
 	import { defineComponent } from 'vue';
-	import { Paperclip, FileIcon, X } from 'lucide-vue-next';
+	import {
+		getTaskFiles,
+		uploadTaskFile,
+		deleteTaskFile,
+		downloadTaskFile,
+		getFilePreviewUrl,
+		getFileTextContent,
+		getFileType,
+		isPreviewable,
+	} from '@/actions/tmgr/files';
 
 	export default defineComponent({
 		name: 'TaskAttachments',
-		components: {
-			Paperclip,
-			FileIcon,
-			X,
-		},
 		props: {
 			taskId: {
 				type: Number,
 				required: false,
 				default: null,
 			},
+			hideEmptyState: {
+				type: Boolean,
+				default: false,
+			},
 		},
+		emits: ['update:count'],
+		expose: ['handleAddFiles'],
 		data() {
 			return {
-				files: [],
+				savedFiles: [],
+				pendingFiles: [],
 				isDragOver: false,
+				isLoading: false,
+				isUploading: false,
+				tempIdCounter: 0,
+				previewFile: null,
+				previewUrl: null,
+				previewContent: null,
+				previewType: null,
+				isLoadingPreview: false,
 			};
 		},
+		computed: {
+			allFiles() {
+				return [...this.savedFiles, ...this.pendingFiles];
+			},
+		},
+		watch: {
+			taskId: {
+				immediate: true,
+				handler(newTaskId) {
+					if (newTaskId) {
+						this.loadFiles();
+					} else {
+						this.savedFiles = [];
+						this.$emit('update:count', 0);
+					}
+				},
+			},
+			'savedFiles.length': {
+				handler(newCount) {
+					this.$emit('update:count', newCount);
+				},
+			},
+		},
 		methods: {
+			async loadFiles() {
+				if (!this.taskId) return;
+
+				this.isLoading = true;
+				try {
+					const files = await getTaskFiles(this.taskId);
+					for (const file of files) {
+						const type = getFileType(file.mimeType, file.name);
+						if (type === 'image') {
+							try {
+								file.thumbnailUrl = await getFilePreviewUrl(file);
+							} catch (e) {
+								console.error('Failed to load thumbnail:', e);
+							}
+						}
+					}
+					this.savedFiles = files;
+					this.$emit('update:count', this.savedFiles.length);
+				} catch (error) {
+					console.error('Failed to load attachments:', error);
+				} finally {
+					this.isLoading = false;
+				}
+			},
+			getFileIcon(file) {
+				const type = getFileType(file.mimeType || null, file.name);
+				switch (type) {
+					case 'image': return 'image';
+					case 'video': return 'movie';
+					case 'pdf': return 'picture_as_pdf';
+					case 'text': return 'description';
+					default: return 'insert_drive_file';
+				}
+			},
+			getFileIconClass(file) {
+				const type = getFileType(file.mimeType || null, file.name);
+				switch (type) {
+					case 'image': return 'text-status-done';
+					case 'video': return 'text-status-testing';
+					case 'pdf': return 'text-status-fix-fg';
+					case 'text': return 'text-brand-fg';
+					default: return 'text-ink-subtle';
+				}
+			},
+			truncateFileName(name, maxLength) {
+				if (!name || name.length <= maxLength) return name;
+				const ext = name.split('.').pop();
+				const nameWithoutExt = name.slice(0, -(ext.length + 1));
+				const truncated = nameWithoutExt.slice(0, maxLength - ext.length - 4);
+				return `${truncated}...${ext}`;
+			},
+			async openPreview(file) {
+				if (file.uploading || !file.id) return;
+
+				const type = getFileType(file.mimeType || null, file.name);
+				if (!isPreviewable(file.mimeType, file.name)) {
+					await this.handleDownloadFile(file);
+					return;
+				}
+
+				this.previewFile = file;
+				this.previewType = type;
+				this.isLoadingPreview = true;
+				this.previewUrl = null;
+				this.previewContent = null;
+
+				try {
+					if (type === 'text') {
+						this.previewContent = await getFileTextContent(file);
+					} else {
+						this.previewUrl = await getFilePreviewUrl(file);
+					}
+				} catch (error) {
+					console.error('Failed to load preview:', error);
+				} finally {
+					this.isLoadingPreview = false;
+				}
+			},
+			closePreview() {
+				if (this.previewUrl) {
+					URL.revokeObjectURL(this.previewUrl);
+				}
+				this.previewFile = null;
+				this.previewUrl = null;
+				this.previewContent = null;
+				this.previewType = null;
+			},
 			handleAddFiles() {
+				if (!this.taskId || this.isUploading) return;
 				this.$refs.fileInput.click();
 			},
 			isImageFile(file) {
-				return file.type.startsWith('image/');
+				return file.type?.startsWith('image/');
 			},
 			createFilePreview(file) {
 				if (this.isImageFile(file)) {
@@ -122,20 +369,82 @@
 				}
 				return null;
 			},
-			handleFileSelect(event) {
+			async handleFileSelect(event) {
 				const selectedFiles = Array.from(event.target.files);
-				selectedFiles.forEach((file) => {
-					file.preview = this.createFilePreview(file);
-					this.files.push(file);
-				});
+				await this.uploadFiles(selectedFiles);
 				event.target.value = '';
 			},
-			handleRemoveFile(index) {
-				const file = this.files[index];
-				if (file.preview) {
-					URL.revokeObjectURL(file.preview);
+			async uploadFiles(files) {
+				if (!this.taskId || files.length === 0) return;
+
+				this.isUploading = true;
+
+				for (const file of files) {
+					const tempId = `temp-${++this.tempIdCounter}`;
+					const pendingFile = {
+						tempId,
+						name: file.name,
+						size: file.size,
+						mimeType: file.type,
+						preview: this.createFilePreview(file),
+						uploading: true,
+					};
+
+					this.pendingFiles.push(pendingFile);
+
+					try {
+						await uploadTaskFile(this.taskId, file);
+						if (pendingFile.preview) {
+							URL.revokeObjectURL(pendingFile.preview);
+						}
+						const index = this.pendingFiles.findIndex(
+							(f) => f.tempId === tempId,
+						);
+						if (index !== -1) {
+							this.pendingFiles.splice(index, 1);
+						}
+					} catch (error) {
+						console.error('Failed to upload file:', error);
+						const index = this.pendingFiles.findIndex(
+							(f) => f.tempId === tempId,
+						);
+						if (index !== -1) {
+							this.pendingFiles.splice(index, 1);
+						}
+					}
 				}
-				this.files.splice(index, 1);
+
+				this.isUploading = false;
+				await this.loadFiles();
+			},
+			async handleRemoveFile(file) {
+				if (file.tempId) {
+					if (file.preview) {
+						URL.revokeObjectURL(file.preview);
+					}
+					const index = this.pendingFiles.findIndex(
+						(f) => f.tempId === file.tempId,
+					);
+					if (index !== -1) {
+						this.pendingFiles.splice(index, 1);
+					}
+					return;
+				}
+
+				if (file.id) {
+					try {
+						if (file.thumbnailUrl) {
+							URL.revokeObjectURL(file.thumbnailUrl);
+						}
+						await deleteTaskFile(file.id, this.taskId);
+						const index = this.savedFiles.findIndex((f) => f.id === file.id);
+						if (index !== -1) {
+							this.savedFiles.splice(index, 1);
+						}
+					} catch (error) {
+						console.error('Failed to delete file:', error);
+					}
+				}
 			},
 			handleDragOver(event) {
 				event.preventDefault();
@@ -147,39 +456,36 @@
 					this.isDragOver = false;
 				}
 			},
-			handleDrop(event) {
+			async handleDrop(event) {
 				event.preventDefault();
 				this.isDragOver = false;
 				const droppedFiles = Array.from(event.dataTransfer.files);
 				if (droppedFiles.length > 0) {
-					droppedFiles.forEach((file) => {
-						file.preview = this.createFilePreview(file);
-						this.files.push(file);
-					});
+					await this.uploadFiles(droppedFiles);
 				}
 			},
-			formatFileSize(bytes) {
-				if (bytes === 0) return '0 Bytes';
-				const k = 1024;
-				const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-				const i = Math.floor(Math.log(bytes) / Math.log(k));
-				return (
-					Math.round((bytes / Math.pow(k, i)) * 100) / 100 + ' ' + sizes[i]
-				);
+			async handleDownloadFile(file) {
+				try {
+					await downloadTaskFile(file, file.name);
+				} catch (error) {
+					console.error('Failed to download file:', error);
+				}
 			},
 		},
 		unmounted() {
-			this.files.forEach((file) => {
+			this.pendingFiles.forEach((file) => {
 				if (file.preview) {
 					URL.revokeObjectURL(file.preview);
 				}
 			});
+			this.savedFiles.forEach((file) => {
+				if (file.thumbnailUrl) {
+					URL.revokeObjectURL(file.thumbnailUrl);
+				}
+			});
+			if (this.previewUrl) {
+				URL.revokeObjectURL(this.previewUrl);
+			}
 		},
 	});
 </script>
-
-<style lang="scss" scoped>
-	.task-attachments {
-		width: 100%;
-	}
-</style>

--- a/src/components/tasks/TaskAttachments.vue
+++ b/src/components/tasks/TaskAttachments.vue
@@ -191,6 +191,7 @@
 		uploadTaskFile,
 		deleteTaskFile,
 		downloadTaskFile,
+		getFileBlob,
 		getFilePreviewUrl,
 		getFileTextContent,
 		getFileType,
@@ -266,7 +267,13 @@
 							const type = getFileType(file.mimeType, file.name);
 							if (type === 'image') {
 								try {
-									file.thumbnailUrl = await getFilePreviewUrl(file);
+									// Keep the blob around, not just an object URL for it —
+									// openPreview derives its own independent URL from the
+									// same blob instead of sharing this one, so this array
+									// can always be swapped/revoked without racing an open
+									// preview modal.
+									file.thumbnailBlob = await getFileBlob(file);
+									file.thumbnailUrl = URL.createObjectURL(file.thumbnailBlob);
 								} catch (e) {
 									console.error('Failed to load thumbnail:', e);
 								}
@@ -339,10 +346,13 @@
 				this.previewUrl = null;
 				this.previewContent = null;
 
-				// The grid thumbnail already holds a blob URL for this exact file;
-				// reuse it instead of re-fetching the full image a second time.
-				if (type === 'image' && file.thumbnailUrl) {
-					this.previewUrl = file.thumbnailUrl;
+				// The grid thumbnail already has this image's blob in memory;
+				// derive our own object URL from it instead of re-fetching over
+				// the network. A fresh URL (not the grid's) means closePreview
+				// can always revoke it without racing loadFiles() replacing the
+				// grid's own thumbnailUrl out from under an open preview.
+				if (type === 'image' && file.thumbnailBlob) {
+					this.previewUrl = URL.createObjectURL(file.thumbnailBlob);
 					return;
 				}
 
@@ -360,10 +370,7 @@
 				}
 			},
 			closePreview() {
-				// Don't revoke if previewUrl is just a reference to the grid
-				// thumbnail's own blob URL (see openPreview) — that one is owned
-				// by loadFiles/unmounted, not by the preview modal.
-				if (this.previewUrl && this.previewUrl !== this.previewFile?.thumbnailUrl) {
+				if (this.previewUrl) {
 					URL.revokeObjectURL(this.previewUrl);
 				}
 				this.previewFile = null;
@@ -498,7 +505,7 @@
 					URL.revokeObjectURL(file.thumbnailUrl);
 				}
 			});
-			if (this.previewUrl && this.previewUrl !== this.previewFile?.thumbnailUrl) {
+			if (this.previewUrl) {
 				URL.revokeObjectURL(this.previewUrl);
 			}
 		},

--- a/src/components/tasks/TaskAttachments.vue
+++ b/src/components/tasks/TaskAttachments.vue
@@ -264,7 +264,7 @@
 					const files = await getTaskFiles(requestedTaskId);
 					await Promise.all(
 						files.map(async (file) => {
-							const type = getFileType(file.mimeType, file.name);
+							const type = getFileType(file.mime_type, file.name);
 							if (type === 'image') {
 								try {
 									// Keep the blob around, not just an object URL for it —
@@ -306,7 +306,7 @@
 				}
 			},
 			getFileIcon(file) {
-				const type = getFileType(file.mimeType || null, file.name);
+				const type = getFileType(file.mime_type || null, file.name);
 				switch (type) {
 					case 'image': return 'image';
 					case 'video': return 'movie';
@@ -316,7 +316,7 @@
 				}
 			},
 			getFileIconClass(file) {
-				const type = getFileType(file.mimeType || null, file.name);
+				const type = getFileType(file.mime_type || null, file.name);
 				switch (type) {
 					case 'image': return 'text-status-done';
 					case 'video': return 'text-status-testing';
@@ -335,8 +335,8 @@
 			async openPreview(file) {
 				if (file.uploading || !file.id) return;
 
-				const type = getFileType(file.mimeType || null, file.name);
-				if (!isPreviewable(file.mimeType, file.name)) {
+				const type = getFileType(file.mime_type || null, file.name);
+				if (!isPreviewable(file.mime_type, file.name)) {
 					await this.handleDownloadFile(file);
 					return;
 				}
@@ -411,7 +411,7 @@
 					tempId,
 					name: file.name,
 					size: file.size,
-					mimeType: file.type,
+					mime_type: file.type,
 					preview: this.createFilePreview(file),
 					uploading: true,
 				});

--- a/src/components/tasks/TaskAttachments.vue
+++ b/src/components/tasks/TaskAttachments.vue
@@ -4,28 +4,24 @@
 			Loading…
 		</div>
 
-		<!-- Grid of thumbnails -->
 		<div v-else-if="allFiles.length > 0" class="flex flex-wrap gap-2">
 			<div
 				v-for="file in allFiles"
 				:key="file.id || file.tempId"
 				class="group relative"
 			>
-				<!-- Thumbnail -->
 				<div
 					@click="openPreview(file)"
 					class="flex h-16 w-16 cursor-pointer items-center justify-center overflow-hidden rounded-card border transition-colors"
 					:class="file.uploading ? 'border-line-strong bg-surface-sunken' : 'border-line bg-surface hover:border-line-strong'"
 					:title="file.name"
 				>
-					<!-- Image thumbnail -->
 					<img
 						v-if="file.thumbnailUrl || file.preview"
 						:src="file.thumbnailUrl || file.preview"
 						:alt="file.name"
 						class="h-full w-full object-cover"
 					/>
-					<!-- File type icon -->
 					<span
 						v-else
 						class="material-icons"
@@ -33,7 +29,6 @@
 						style="font-size: 26px"
 						>{{ getFileIcon(file) }}</span
 					>
-					<!-- Uploading overlay -->
 					<div
 						v-if="file.uploading"
 						class="absolute inset-0 flex items-center justify-center bg-surface/60"
@@ -42,7 +37,6 @@
 					</div>
 				</div>
 
-				<!-- Actions (on hover) -->
 				<div
 					v-if="!file.uploading"
 					class="absolute -right-1 -top-1 flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100"
@@ -66,7 +60,6 @@
 					</button>
 				</div>
 
-				<!-- File name tooltip on hover -->
 				<div
 					class="pointer-events-none absolute left-1/2 top-full z-10 mt-1 hidden -translate-x-1/2 whitespace-nowrap rounded-md bg-ink px-2 py-1 text-2xs text-surface-base group-hover:block"
 				>
@@ -74,7 +67,6 @@
 				</div>
 			</div>
 
-			<!-- Add more button -->
 			<div
 				v-if="taskId && !isUploading"
 				@click="handleAddFiles"
@@ -85,11 +77,9 @@
 			</div>
 		</div>
 
-		<!-- Empty state with drop zone (hidden when hideEmptyState is true) -->
 		<template v-else-if="!hideEmptyState">
 			<div class="text-2xs text-ink-subtle">No attachments yet</div>
 
-			<!-- Drop zone -->
 			<div
 				v-if="taskId"
 				@click="handleAddFiles"
@@ -113,7 +103,6 @@
 			@change="handleFileSelect"
 		/>
 
-		<!-- Preview Modal -->
 		<div
 			v-if="previewFile"
 			class="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
@@ -123,7 +112,6 @@
 				class="relative max-h-[90vh] max-w-[90vw] overflow-auto rounded-card border border-line bg-surface shadow-2xl"
 				@click.stop
 			>
-				<!-- Modal Header -->
 				<div class="sticky top-0 z-10 flex items-center justify-between border-b border-line bg-surface px-4 py-3">
 					<h3 class="truncate text-sm font-semibold text-ink">
 						{{ previewFile.name }}
@@ -148,14 +136,11 @@
 					</div>
 				</div>
 
-				<!-- Modal Content -->
 				<div class="p-4">
-					<!-- Loading -->
 					<div v-if="isLoadingPreview" class="flex h-64 w-96 items-center justify-center">
 						<div class="h-8 w-8 animate-spin rounded-full border-4 border-brand border-t-transparent"></div>
 					</div>
 
-					<!-- Image Preview -->
 					<img
 						v-else-if="previewType === 'image' && previewUrl"
 						:src="previewUrl"
@@ -163,7 +148,6 @@
 						class="max-h-[70vh] max-w-full object-contain"
 					/>
 
-					<!-- Video Preview -->
 					<video
 						v-else-if="previewType === 'video' && previewUrl"
 						:src="previewUrl"
@@ -171,20 +155,17 @@
 						class="max-h-[70vh] max-w-full"
 					/>
 
-					<!-- PDF Preview -->
 					<iframe
 						v-else-if="previewType === 'pdf' && previewUrl"
 						:src="previewUrl"
 						class="h-[70vh] w-[800px] max-w-full"
 					/>
 
-					<!-- Text Preview -->
 					<pre
-						v-else-if="previewType === 'text' && previewContent"
+						v-else-if="previewType === 'text' && previewContent !== null"
 						class="max-h-[70vh] max-w-[800px] overflow-auto rounded-md bg-surface-sunken p-4 text-sm text-ink"
 					>{{ previewContent }}</pre>
 
-					<!-- Unsupported type -->
 					<div v-else class="flex h-64 w-96 flex-col items-center justify-center text-ink-subtle">
 						<span class="material-icons mb-4" style="font-size: 48px">insert_drive_file</span>
 						<p class="text-sm">Preview not available for this file type</p>
@@ -204,6 +185,7 @@
 
 <script>
 	import { defineComponent } from 'vue';
+	import { toast } from '@/components/ui/toast/use-toast';
 	import {
 		getTaskFiles,
 		uploadTaskFile,
@@ -272,25 +254,48 @@
 			async loadFiles() {
 				if (!this.taskId) return;
 
+				// taskId can change on the same component instance (e.g. creating
+				// a task assigns form.id after mount); guard against an in-flight
+				// load for the previous id resolving after a newer one started.
+				const requestedTaskId = this.taskId;
 				this.isLoading = true;
 				try {
-					const files = await getTaskFiles(this.taskId);
-					for (const file of files) {
-						const type = getFileType(file.mimeType, file.name);
-						if (type === 'image') {
-							try {
-								file.thumbnailUrl = await getFilePreviewUrl(file);
-							} catch (e) {
-								console.error('Failed to load thumbnail:', e);
+					const files = await getTaskFiles(requestedTaskId);
+					await Promise.all(
+						files.map(async (file) => {
+							const type = getFileType(file.mimeType, file.name);
+							if (type === 'image') {
+								try {
+									file.thumbnailUrl = await getFilePreviewUrl(file);
+								} catch (e) {
+									console.error('Failed to load thumbnail:', e);
+								}
 							}
-						}
+						}),
+					);
+
+					if (this.taskId !== requestedTaskId) {
+						files.forEach((file) => {
+							if (file.thumbnailUrl) {
+								URL.revokeObjectURL(file.thumbnailUrl);
+							}
+						});
+						return;
 					}
+
+					this.savedFiles.forEach((file) => {
+						if (file.thumbnailUrl) {
+							URL.revokeObjectURL(file.thumbnailUrl);
+						}
+					});
 					this.savedFiles = files;
 					this.$emit('update:count', this.savedFiles.length);
 				} catch (error) {
 					console.error('Failed to load attachments:', error);
 				} finally {
-					this.isLoading = false;
+					if (this.taskId === requestedTaskId) {
+						this.isLoading = false;
+					}
 				}
 			},
 			getFileIcon(file) {
@@ -331,10 +336,17 @@
 
 				this.previewFile = file;
 				this.previewType = type;
-				this.isLoadingPreview = true;
 				this.previewUrl = null;
 				this.previewContent = null;
 
+				// The grid thumbnail already holds a blob URL for this exact file;
+				// reuse it instead of re-fetching the full image a second time.
+				if (type === 'image' && file.thumbnailUrl) {
+					this.previewUrl = file.thumbnailUrl;
+					return;
+				}
+
+				this.isLoadingPreview = true;
 				try {
 					if (type === 'text') {
 						this.previewContent = await getFileTextContent(file);
@@ -348,7 +360,10 @@
 				}
 			},
 			closePreview() {
-				if (this.previewUrl) {
+				// Don't revoke if previewUrl is just a reference to the grid
+				// thumbnail's own blob URL (see openPreview) — that one is owned
+				// by loadFiles/unmounted, not by the preview modal.
+				if (this.previewUrl && this.previewUrl !== this.previewFile?.thumbnailUrl) {
 					URL.revokeObjectURL(this.previewUrl);
 				}
 				this.previewFile = null;
@@ -374,75 +389,70 @@
 				await this.uploadFiles(selectedFiles);
 				event.target.value = '';
 			},
+			removePendingFile(tempId) {
+				const index = this.pendingFiles.findIndex((f) => f.tempId === tempId);
+				if (index !== -1) {
+					const [removed] = this.pendingFiles.splice(index, 1);
+					if (removed.preview) {
+						URL.revokeObjectURL(removed.preview);
+					}
+				}
+			},
+			async uploadOneFile(file) {
+				const tempId = `temp-${++this.tempIdCounter}`;
+				this.pendingFiles.push({
+					tempId,
+					name: file.name,
+					size: file.size,
+					mimeType: file.type,
+					preview: this.createFilePreview(file),
+					uploading: true,
+				});
+
+				try {
+					await uploadTaskFile(this.taskId, file);
+					this.removePendingFile(tempId);
+				} catch (error) {
+					console.error('Failed to upload file:', error);
+					this.removePendingFile(tempId);
+					toast({
+						title: 'Upload failed',
+						description: `"${file.name}" couldn't be attached. Please try again.`,
+						variant: 'destructive',
+					});
+				}
+			},
 			async uploadFiles(files) {
 				if (!this.taskId || files.length === 0) return;
 
 				this.isUploading = true;
-
-				for (const file of files) {
-					const tempId = `temp-${++this.tempIdCounter}`;
-					const pendingFile = {
-						tempId,
-						name: file.name,
-						size: file.size,
-						mimeType: file.type,
-						preview: this.createFilePreview(file),
-						uploading: true,
-					};
-
-					this.pendingFiles.push(pendingFile);
-
-					try {
-						await uploadTaskFile(this.taskId, file);
-						if (pendingFile.preview) {
-							URL.revokeObjectURL(pendingFile.preview);
-						}
-						const index = this.pendingFiles.findIndex(
-							(f) => f.tempId === tempId,
-						);
-						if (index !== -1) {
-							this.pendingFiles.splice(index, 1);
-						}
-					} catch (error) {
-						console.error('Failed to upload file:', error);
-						const index = this.pendingFiles.findIndex(
-							(f) => f.tempId === tempId,
-						);
-						if (index !== -1) {
-							this.pendingFiles.splice(index, 1);
-						}
-					}
-				}
-
+				await Promise.allSettled(files.map((file) => this.uploadOneFile(file)));
 				this.isUploading = false;
 				await this.loadFiles();
 			},
 			async handleRemoveFile(file) {
 				if (file.tempId) {
-					if (file.preview) {
-						URL.revokeObjectURL(file.preview);
-					}
-					const index = this.pendingFiles.findIndex(
-						(f) => f.tempId === file.tempId,
-					);
-					if (index !== -1) {
-						this.pendingFiles.splice(index, 1);
-					}
+					this.removePendingFile(file.tempId);
 					return;
 				}
 
 				if (file.id) {
 					try {
+						await deleteTaskFile(file.id, this.taskId);
 						if (file.thumbnailUrl) {
 							URL.revokeObjectURL(file.thumbnailUrl);
 						}
-						await deleteTaskFile(file.id, this.taskId);
 						const index = this.savedFiles.findIndex((f) => f.id === file.id);
 						if (index !== -1) {
 							this.savedFiles.splice(index, 1);
 						}
 					} catch (error) {
 						console.error('Failed to delete file:', error);
+						toast({
+							title: 'Remove failed',
+							description: `"${file.name}" couldn't be removed. Please try again.`,
+							variant: 'destructive',
+						});
 					}
 				}
 			},
@@ -469,6 +479,11 @@
 					await downloadTaskFile(file, file.name);
 				} catch (error) {
 					console.error('Failed to download file:', error);
+					toast({
+						title: 'Download failed',
+						description: `"${file.name}" couldn't be downloaded. Please try again.`,
+						variant: 'destructive',
+					});
 				}
 			},
 		},
@@ -483,7 +498,7 @@
 					URL.revokeObjectURL(file.thumbnailUrl);
 				}
 			});
-			if (this.previewUrl) {
+			if (this.previewUrl && this.previewUrl !== this.previewFile?.thumbnailUrl) {
 				URL.revokeObjectURL(this.previewUrl);
 			}
 		},

--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -274,6 +274,8 @@
 	const titleTextarea = ref<HTMLTextAreaElement | null>(null);
 	const taskCommentsRef = ref<InstanceType<typeof TaskComments> | null>(null);
 	const taskRelationsRef = ref<InstanceType<typeof TaskRelations> | null>(null);
+	const attachmentsRef = ref<InstanceType<typeof TaskAttachments> | null>(null);
+	const attachmentsCount = ref(0);
 
 	function openLinkDialog() {
 		taskRelationsRef.value?.startAdding?.();
@@ -1730,10 +1732,34 @@
 					</div>
 
 					<!-- Task Attachments -->
-					<!--					<TaskAttachments
-						v-if="taskId || form.id"
-						:task-id="taskId || form.id"
-					/>-->
+					<section v-if="taskId || form.id" class="flex flex-col gap-2">
+						<div class="flex items-center justify-between gap-2">
+							<div class="flex items-baseline gap-2">
+								<span
+									class="text-2xs font-bold uppercase tracking-wide text-ink-subtle"
+									>Attachments</span
+								>
+								<span
+									v-if="attachmentsCount"
+									class="text-2xs text-ink-faint"
+									>· {{ attachmentsCount }}</span
+								>
+							</div>
+							<button
+								type="button"
+								@click="attachmentsRef?.handleAddFiles()"
+								class="flex h-7 items-center gap-1 rounded-pill border border-dashed border-line-strong px-2.5 text-2xs font-semibold text-ink-subtle transition hover:bg-surface-sunken hover:text-ink"
+							>
+								<span class="material-icons" style="font-size: 14px">add</span>
+								Add file
+							</button>
+						</div>
+						<TaskAttachments
+							ref="attachmentsRef"
+							:task-id="taskId || form.id"
+							@update:count="attachmentsCount = $event"
+						/>
+					</section>
 
 					<!-- CHECKPOINTS = time log (start -> end, description, duration) -->
 					<section


### PR DESCRIPTION
## Summary
Revives TM-119 (task attachments UI, shipped commented-out in `NewForm.vue` since PR #156) and wires it to TM-133's S3 storage — both tickets land as one cohesive feature since the frontend upload flow *is* the S3 integration.

There was a stale, never-merged branch (`origin/TM-119-dobavit-atacmenty-k`, last touched Jan 30) with a substantial real implementation (`files.ts`, a full `TaskAttachments.vue` rewrite) — rather than redo the work, I took it as a starting point, then rebuilt the API layer once I found it targeted a contract the backend never actually implements (direct multipart upload + blob-returning GET). Verified the real contract against `backend-java` source directly (`TaskFileController`, `PresignedUrlController`, `S3Service`, `TaskFileAttachRequest`/`TaskFileDto`, the `task_files` migrations):

- Upload: `POST /api/files/presign-upload {fileName, contentType}` → `{key, upload_url}` → client `PUT`s the file straight to S3 (bare `fetch`, not `$axios` — a bearer token/30s timeout don't belong on an arbitrary-size direct-to-S3 upload; S3 also requires the `Content-Type` header on the PUT to match what was signed) → `POST /tasks/{id}/files {fileName, filePath: key, mimeType, sizeBytes}` (JSON, not multipart) to register the metadata.
- Preview/download: `GET /files/{id}` only returns JSON metadata, not bytes, so both go through `POST /api/files/presign-download {key}` first.
- `TaskFileDto` serializes camelCase (`filePath`, `mimeType`, etc.) — the frontend's `TaskFile` interface matches that, deliberately unlike the rest of this app's snake_case Task-related types (those target the older PHP backend).

`TaskAttachments.vue` keeps the stale branch's upload/preview/drag-drop UX but is restyled onto this repo's current `ink`/`surface`/`brand`/`line` design tokens + `material-icons` (matching the adjacent Checkpoints section) instead of the old raw-Tailwind-gray/lucide-icon styling, which predates the OKLCH redesign. Wired into `NewForm.vue` with the same header-row pattern as Checkpoints (label, count, dashed "Add file" pill).

Did **not** port the stale branch's `TaskComments.vue`/`TaskRelations.vue` changes — confirmed (independently, via a second pair of eyes) those are fully superseded by this repo's own later evolution (`hide-header` prop, right-rail layout, lazy comment counts); porting them would have reverted newer work for no gain.

## Known backend gap (flagged to PM/backend-lead, not fixed here — out of frontend scope)
`TaskFile.deletedAt` is `@Transient` (no `deleted_at` column exists on `task_files`), and the repository's list query doesn't filter on it either — so `DELETE /files/{id}` returns 204 but doesn't durably remove the attachment; it reappears after the task is reloaded. The UI still calls delete and optimistically removes the row locally (correct within the session), so this isn't blocking, but QA should expect a reload to bring deleted files back until the backend fix lands.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 124/124 passing (no regression; no existing test coverage of `actions/tmgr/*` or Vue SFCs in this repo's jest config)
- [x] Standalone logic simulation of the upload/preview sequencing (presign → PUT with matching Content-Type → attach with camelCase fields; preview via `filePath` not `id`) — all scenarios pass
- [ ] QA: no local `backend-java` env is up (WIP branch, not deployed) — needs live verification once available: upload/list/preview/download/delete round-trip, and confirm the known delete-doesn't-persist gap