### PR TITLE
feat(TM-105): dedicated task key input, unique per category

### DIFF
--- a/src/actions/tmgr/categories.ts
+++ b/src/actions/tmgr/categories.ts
@@ -4,6 +4,7 @@ import { requestCache } from '@/utils/requestCache';
 
 export interface Category {
 	children_count: number;
+	code?: string | null;
 	created_at: string;
 	deleted_at: null | string;
 	id: number;

--- a/src/actions/tmgr/tasks.ts
+++ b/src/actions/tmgr/tasks.ts
@@ -25,6 +25,7 @@ export interface Task {
 	is_daily_routine: boolean;
 	order: number;
 	project_category_id?: number | null;
+	category_tasks_sequence_id?: number | null;
 	settings?: FormSetting[];
 	start_time: number;
 	status_id: number;

--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -14,6 +14,7 @@
 		PlayCircleIcon,
 		PauseCircleIcon,
 		LinkIcon,
+		HashtagIcon,
 	} from '@heroicons/vue/24/outline';
 	import store from '@/store';
 	import {
@@ -330,6 +331,32 @@
 			(c: Category) => c.id === form.value.project_category_id,
 		);
 	});
+
+	const taskKeyError = ref<string | null>(null);
+
+	const taskDisplayKey = computed(() => {
+		if (currentCategoryCode.value && form.value.category_tasks_sequence_id) {
+			return `${currentCategoryCode.value}-${form.value.category_tasks_sequence_id}`;
+		}
+		return `TMGR-T${taskId.value || form.value.id}`;
+	});
+
+	const taskKeyNumber = computed({
+		get: () => form.value.category_tasks_sequence_id ?? '',
+		set: (value: number | string) => {
+			form.value.category_tasks_sequence_id =
+				value === '' || value === null ? null : Number(value);
+			taskKeyError.value = null;
+		},
+	});
+
+	const handleTaskSaveError = (e: any) => {
+		console.error(e);
+		if (e?.response?.status === 409) {
+			taskKeyError.value =
+				'This key is already used in this category — try another number, or clear it to auto-assign.';
+		}
+	};
 
 	const hasActiveAgent = computed(() => {
 		return cursorAgents.value.some((a: any) => a.status === 'RUNNING');
@@ -924,7 +951,7 @@
 
 			store.commit('incrementReloadTasksKey');
 		} catch (e) {
-			console.error(e);
+			handleTaskSaveError(e);
 		}
 	};
 
@@ -1014,7 +1041,7 @@
 			// We need to set this after the save operation completes
 			suppressAutoSavingForOnce.value = true;
 		} catch (e) {
-			console.error(e);
+			handleTaskSaveError(e);
 		} finally {
 			isLoading.value = false;
 		}
@@ -1146,6 +1173,7 @@
 			'description',
 			// 'description_json', // TODO: need to fix update in this editor
 			'project_category_id',
+			'category_tasks_sequence_id',
 			'assignees',
 			'status',
 		],
@@ -1470,7 +1498,7 @@
 							v-if="taskId || form.id"
 							class="font-mono text-2xs text-ink-subtle truncate"
 						>
-							TMGR-T{{ taskId || form.id }}
+							{{ taskDisplayKey }}
 						</span>
 					</div>
 
@@ -1638,10 +1666,33 @@
 										if (!form.title) {
 											updateTaskTitle();
 										}
+										form.category_tasks_sequence_id = null;
+										taskKeyError = null;
 									}
 								"
 							/>
 						</div>
+
+						<template v-if="form.project_category_id">
+							<div class="flex items-center gap-2 text-ink-subtle">
+								<HashtagIcon class="h-3.5 w-3.5" />
+								<span>Key</span>
+							</div>
+							<div class="flex min-w-0 items-center gap-1.5">
+								<span class="shrink-0 font-mono text-sm text-ink-subtle">{{ currentCategoryCode || 'TASK' }}-</span>
+								<input
+									type="number"
+									min="1"
+									step="1"
+									v-model="taskKeyNumber"
+									placeholder="auto"
+									class="w-20 min-w-0 rounded-md border border-line bg-surface-sunken px-2 py-1 font-mono text-sm text-ink outline-none placeholder:text-ink-faint focus:border-line-strong"
+								/>
+							</div>
+							<div v-if="taskKeyError" class="col-span-2 -mt-2 text-xs text-status-fix-fg">
+								{{ taskKeyError }}
+							</div>
+						</template>
 
 						<template v-if="form.id">
 							<div class="flex items-center gap-2 text-ink-subtle">

--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -189,7 +189,7 @@
 	const instanceId = `new-form-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
 	const hasTaskMeaningfulChanges = (current: Task, incoming: any): boolean => {
-		const fieldsToCompare = ['title', 'description', 'description_json', 'status_id', 'project_category_id', 'expired_at', 'approximately_time', 'checkpoints'];
+		const fieldsToCompare = ['title', 'description', 'description_json', 'status_id', 'project_category_id', 'category_tasks_sequence_id', 'expired_at', 'approximately_time', 'checkpoints'];
 		for (const field of fieldsToCompare) {
 			const currentVal = current[field as keyof Task];
 			const incomingVal = incoming[field];
@@ -335,7 +335,7 @@
 	const taskKeyError = ref<string | null>(null);
 
 	const taskDisplayKey = computed(() => {
-		if (currentCategoryCode.value && form.value.category_tasks_sequence_id) {
+		if (currentCategoryCode.value && form.value.category_tasks_sequence_id != null) {
 			return `${currentCategoryCode.value}-${form.value.category_tasks_sequence_id}`;
 		}
 		return `TMGR-T${taskId.value || form.value.id}`;
@@ -344,8 +344,17 @@
 	const taskKeyNumber = computed({
 		get: () => form.value.category_tasks_sequence_id ?? '',
 		set: (value: number | string) => {
-			form.value.category_tasks_sequence_id =
-				value === '' || value === null ? null : Number(value);
+			if (value === '') {
+				form.value.category_tasks_sequence_id = null;
+				taskKeyError.value = null;
+				return;
+			}
+			const parsed = Number(value);
+			if (!Number.isInteger(parsed) || parsed < 1) {
+				taskKeyError.value = 'Enter a whole number of 1 or greater, or leave it blank to auto-assign.';
+				return;
+			}
+			form.value.category_tasks_sequence_id = parsed;
 			taskKeyError.value = null;
 		},
 	});
@@ -354,7 +363,7 @@
 		console.error(e);
 		if (e?.response?.status === 409) {
 			taskKeyError.value =
-				'This key is already used in this category — try another number, or clear it to auto-assign.';
+				"There's a conflict saving this task — if you set a custom key, try another number or clear it to auto-assign.";
 		}
 	};
 
@@ -1666,8 +1675,7 @@
 										if (!form.title) {
 											updateTaskTitle();
 										}
-										form.category_tasks_sequence_id = null;
-										taskKeyError = null;
+										taskKeyNumber = '';
 									}
 								"
 							/>
@@ -1688,6 +1696,7 @@
 									placeholder="auto"
 									class="w-20 min-w-0 rounded-md border border-line bg-surface-sunken px-2 py-1 font-mono text-sm text-ink outline-none placeholder:text-ink-faint focus:border-line-strong"
 								/>
+								<span v-if="isAutoSaving && !taskKeyError" class="text-2xs text-ink-faint">Saving…</span>
 							</div>
 							<div v-if="taskKeyError" class="col-span-2 -mt-2 text-xs text-status-fix-fg">
 								{{ taskKeyError }}

--- a/src/pages/ProjectCategoryList.vue
+++ b/src/pages/ProjectCategoryList.vue
@@ -150,6 +150,7 @@
 
 		await updateTaskPartially(taskId, {
 			project_category_id: categoryId,
+			category_tasks_sequence_id: null,
 		});
 
 		await loadCategories();

--- a/src/pages/ProjectCategoryList.vue
+++ b/src/pages/ProjectCategoryList.vue
@@ -150,7 +150,6 @@
 
 		await updateTaskPartially(taskId, {
 			project_category_id: categoryId,
-			category_tasks_sequence_id: null,
 		});
 
 		await loadCategories();


### PR DESCRIPTION
## Summary
Adds a dedicated "task key" input to the task form (e.g. `ENG-42`), backed by TM-86's new per-category sequence field. Verified the backend contract directly from source on `feature/TM-86` (not yet merged into `backend-java` — same WIP status as the files module TM-119/TM-133 depended on):

- `Task.categoryTasksSequenceId` (DB: `category_tasks_sequence_id`, nullable `Long`, unique per `project_category_id` via a composite DB index) — client can set it explicitly on create/update, or omit/null it for server auto-assignment.
- A collision within the same category returns **409** (`TaskService.mapDuplicateSequence`, a `ResponseStatusException(CONFLICT, ...)` — generic Spring error body, no structured field info, so the frontend keys off the status code alone).

## What changed
- `Task.category_tasks_sequence_id?: number | null` and `Category.code?: string | null` (a pre-existing typing gap — `category.code` was already read at runtime via `currentCategoryCode`, just never in the `Category` interface) added to the action-layer types.
- New "Key" row in `NewForm.vue`'s properties grid, shown once a category is picked: fixed `{CODE}-` prefix + a number input for the sequence (blank = auto-assign). Wired into the form's existing debounced-autosave field list alongside every other property.
- The header's task-id shorthand — previously a hardcoded `TMGR-T{id}` — now shows the real `{CODE}-{sequence}` once one is assigned, falling back to the old format for tasks that don't have one yet (i.e. every existing task, until it gets a sequence assigned).
- Changing category clears any manually-entered sequence number, since it's scoped to the category — silently carrying a number over to a different category would be confusing.
- A 409 on create/save now surfaces as an inline error under the Key input. `createTask`/`saveTask` previously swallowed every error with only `console.error`; this adds visible handling *only* for the 409 case, not a broader error-handling change beyond this ticket's scope.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 124/124 passing (no regression)
- [x] Standalone logic simulation of the display/input computed logic (real-key vs fallback-key formatting, clear-on-category-change, null-vs-number handling) — all scenarios pass
- [ ] QA: no local `backend-java`/`feature/TM-86` instance is reachable to test the live 409 round-trip (branch isn't deployed anywhere yet) — needs a real pass once that lands, same caveat as TM-119/TM-133