### PR TITLE
fix(TM-8874): realtime list reconciliation blind to search/category/pagination [stacked on #185]

### DIFF
--- a/src/pages/TasksListPage.vue
+++ b/src/pages/TasksListPage.vue
@@ -82,6 +82,36 @@
 		});
 	}
 
+	// Whether a realtime task update matches everything this view's server
+	// query would filter on, EXCEPT pagination (a task can match every active
+	// filter and still live on some other page - callers that are about to
+	// INSERT a not-yet-visible row must additionally check
+	// pagination.value.current_page === 1; callers EVICTING an already-visible
+	// row don't need to, since presence in tasks.value already proves it was
+	// on the current page).
+	//
+	// searchText isn't checked here: the server's search semantics (title
+	// only? description too? fuzzy?) aren't reliably reproducible client-side,
+	// so a task is only ever treated as "belongs" via this function when no
+	// search is active - callers skip realtime insert/evict entirely while
+	// the user is searching, rather than risk a wrong client-side guess.
+	function matchesActiveFilters(task: Task): boolean {
+		if (status.value && task.status !== status.value) return false;
+		if (searchText.value) return false;
+		if (
+			selectedCategory.value != null &&
+			selectedCategory.value !== -1 &&
+			task.project_category_id !== selectedCategory.value
+		) {
+			return false;
+		}
+		return true;
+	}
+
+	function shouldBeInList(task: Task): boolean {
+		return matchesActiveFilters(task) && !(isActiveList.value && isArchivedTask(task));
+	}
+
 	const totalSeconds = computed(() =>
 		pagination.value?.total_seconds || tasks.value.reduce((summary, task) => task.common_time + summary, 0)
 	);
@@ -176,34 +206,34 @@
 				pusherSubscriptionId.value = subscribeToWorkspace(workspaceId.value, {
 					onTaskUpdated: (task, action) => {
 						if (action === 'created') {
-							if (isActiveList.value && isArchivedTask(task)) {
-								return;
-							}
-							const matchesStatus = !status.value || task.status === status.value;
 							const exists = tasks.value.some(t => t.id === task.id);
-							if (matchesStatus && !exists) {
+							if (!exists && shouldBeInList(task) && pagination.value.current_page === 1) {
 								tasks.value.unshift(task);
 								pagination.value.total++;
 							}
 						} else if (action === 'updated') {
 							const index = tasks.value.findIndex(t => t.id === task.id);
-							const matchesStatus = !status.value || task.status === status.value;
-							const shouldBeInList = matchesStatus && !(isActiveList.value && isArchivedTask(task));
+							const belongs = shouldBeInList(task);
 
 							if (index !== -1) {
-								if (shouldBeInList) {
+								if (belongs) {
 									tasks.value.splice(index, 1, task);
 								} else {
 									tasks.value.splice(index, 1);
 									pagination.value.total = Math.max(0, pagination.value.total - 1);
 								}
-							} else if (shouldBeInList) {
+							} else if (belongs && pagination.value.current_page === 1) {
 								tasks.value.unshift(task);
 								pagination.value.total++;
 							}
 						} else if (action === 'deleted') {
-							tasks.value = tasks.value.filter(t => t.id !== task.id);
-							pagination.value.total = Math.max(0, pagination.value.total - 1);
+							const index = tasks.value.findIndex(t => t.id === task.id);
+							if (index !== -1) {
+								tasks.value.splice(index, 1);
+							}
+							if (index !== -1 || shouldBeInList(task)) {
+								pagination.value.total = Math.max(0, pagination.value.total - 1);
+							}
 						}
 					},
 					onCommentAdded: (comment) => {
@@ -366,27 +396,18 @@
 
 	function updateSingleTaskInList(updatedTask: Task) {
 		const taskIndex = tasks.value.findIndex(t => t.id === updatedTask.id);
-		const isArchivedOnActiveList = isActiveList.value && isArchivedTask(updatedTask);
+		const belongs = shouldBeInList(updatedTask);
 
 		if (taskIndex !== -1) {
-			const shouldStayInList =
-				!isArchivedOnActiveList &&
-				(!status.value || updatedTask.status === status.value);
-
-			if (shouldStayInList) {
+			if (belongs) {
 				tasks.value.splice(taskIndex, 1, updatedTask);
 			} else {
 				tasks.value.splice(taskIndex, 1);
 				pagination.value.total = Math.max(0, pagination.value.total - 1);
 			}
-		} else {
-			const shouldBeInList =
-				!isArchivedOnActiveList &&
-				(!status.value || updatedTask.status === status.value);
-			if (shouldBeInList) {
-				tasks.value.unshift(updatedTask);
-				pagination.value.total++;
-			}
+		} else if (belongs && pagination.value.current_page === 1) {
+			tasks.value.unshift(updatedTask);
+			pagination.value.total++;
 		}
 	}
 </script>

--- a/src/pages/TasksListPage.vue
+++ b/src/pages/TasksListPage.vue
@@ -82,22 +82,17 @@
 		});
 	}
 
-	// Whether a realtime task update matches everything this view's server
-	// query would filter on, EXCEPT pagination (a task can match every active
-	// filter and still live on some other page - callers that are about to
-	// INSERT a not-yet-visible row must additionally check
-	// pagination.value.current_page === 1; callers EVICTING an already-visible
-	// row don't need to, since presence in tasks.value already proves it was
-	// on the current page).
-	//
-	// searchText isn't checked here: the server's search semantics (title
-	// only? description too? fuzzy?) aren't reliably reproducible client-side,
-	// so a task is only ever treated as "belongs" via this function when no
-	// search is active - callers skip realtime insert/evict entirely while
-	// the user is searching, rather than risk a wrong client-side guess.
-	function matchesActiveFilters(task: Task): boolean {
+	// Status, archived-state and selectedCategory are all fields we can
+	// reliably compare client-side, so a mismatch on any of them is trusted
+	// in BOTH directions: it blocks inserting a not-yet-visible task, and it
+	// evicts an already-visible one whose data just changed to no longer
+	// match. searchText is excluded on purpose - the server's search
+	// semantics (title only? description too? fuzzy?) aren't reproducible
+	// client-side, so it can't feed a reliable-in-both-directions check;
+	// see canInsertTask for how it's actually used.
+	function matchesKnownFilters(task: Task): boolean {
 		if (status.value && task.status !== status.value) return false;
-		if (searchText.value) return false;
+		if (isActiveList.value && isArchivedTask(task)) return false;
 		if (
 			selectedCategory.value != null &&
 			selectedCategory.value !== -1 &&
@@ -108,8 +103,18 @@
 		return true;
 	}
 
-	function shouldBeInList(task: Task): boolean {
-		return matchesActiveFilters(task) && !(isActiveList.value && isArchivedTask(task));
+	// Whether a realtime event can safely INSERT a not-yet-visible task (or,
+	// for a delete of an off-page task, whether it was safely countable in
+	// pagination.value.total to begin with). Unlike matchesKnownFilters, an
+	// active search says no here - we can't verify a not-yet-visible task
+	// matches the search, so the safe default is to skip rather than guess.
+	// This must NOT be used to decide whether to EVICT an already-visible
+	// task: an active search we can't verify means "leave it alone", not
+	// "remove it" - callers with a task already in tasks.value should evict
+	// only on a matchesKnownFilters mismatch, never merely because a search
+	// is active.
+	function canInsertTask(task: Task): boolean {
+		return !searchText.value && matchesKnownFilters(task);
 	}
 
 	const totalSeconds = computed(() =>
@@ -207,22 +212,21 @@
 					onTaskUpdated: (task, action) => {
 						if (action === 'created') {
 							const exists = tasks.value.some(t => t.id === task.id);
-							if (!exists && shouldBeInList(task) && pagination.value.current_page === 1) {
+							if (!exists && canInsertTask(task) && pagination.value.current_page === 1) {
 								tasks.value.unshift(task);
 								pagination.value.total++;
 							}
 						} else if (action === 'updated') {
 							const index = tasks.value.findIndex(t => t.id === task.id);
-							const belongs = shouldBeInList(task);
 
 							if (index !== -1) {
-								if (belongs) {
+								if (matchesKnownFilters(task)) {
 									tasks.value.splice(index, 1, task);
 								} else {
 									tasks.value.splice(index, 1);
 									pagination.value.total = Math.max(0, pagination.value.total - 1);
 								}
-							} else if (belongs && pagination.value.current_page === 1) {
+							} else if (canInsertTask(task) && pagination.value.current_page === 1) {
 								tasks.value.unshift(task);
 								pagination.value.total++;
 							}
@@ -231,7 +235,7 @@
 							if (index !== -1) {
 								tasks.value.splice(index, 1);
 							}
-							if (index !== -1 || shouldBeInList(task)) {
+							if (index !== -1 || canInsertTask(task)) {
 								pagination.value.total = Math.max(0, pagination.value.total - 1);
 							}
 						}
@@ -396,16 +400,15 @@
 
 	function updateSingleTaskInList(updatedTask: Task) {
 		const taskIndex = tasks.value.findIndex(t => t.id === updatedTask.id);
-		const belongs = shouldBeInList(updatedTask);
 
 		if (taskIndex !== -1) {
-			if (belongs) {
+			if (matchesKnownFilters(updatedTask)) {
 				tasks.value.splice(taskIndex, 1, updatedTask);
 			} else {
 				tasks.value.splice(taskIndex, 1);
 				pagination.value.total = Math.max(0, pagination.value.total - 1);
 			}
-		} else if (belongs && pagination.value.current_page === 1) {
+		} else if (canInsertTask(updatedTask) && pagination.value.current_page === 1) {
 			tasks.value.unshift(updatedTask);
 			pagination.value.total++;
 		}


### PR DESCRIPTION
## Summary
Follow-up to TM-8861 (#185) — flagged there as a known, deliberately out-of-scope gap, tracked as its own ticket. **Stacked on #185**: base branch is `feature/TM-8861-unarchive-realtime`, not `master`, since this extends the `shouldBeInList` predicate that PR introduced. Merge #185 first, or diff/review this PR against #185's tip rather than `master`.

The `created`/`updated` realtime handlers and `updateSingleTaskInList` in `TasksListPage.vue` all matched on status alone, blind to an active `searchText`, `selectedCategory`, or which page is currently loaded. A realtime event could insert a row that doesn't match the active search/category filter, or inflate `pagination.total` for a task that only matched by status while actually sitting on a different page of the same filtered result set.

## What changed
Consolidated the three independently hand-rolled "does this task belong in the current view" checks into two shared functions:
- `matchesActiveFilters(task)` — status + `selectedCategory` (a real, reliably-comparable field) match the current view. `searchText` is **deliberately not** matched against — the server's search semantics (title only? description too? fuzzy?) aren't reproducible client-side, so realtime insert/evict is skipped entirely while a search is active rather than risk a wrong client-side guess.
- `shouldBeInList(task)` — `matchesActiveFilters` + the existing archived-on-active-list exclusion from TM-8829/TM-8861.

Callers **inserting** a not-yet-visible row now additionally require `pagination.value.current_page === 1` — we can't know if a task belongs on the specific page currently loaded, so only insert where "a newly-matching item goes at the top" is a safe assumption. Callers **evicting** an already-visible row don't need that check, since presence in `tasks.value` already proves it was on the current page.

Also extended the `deleted` branch to the same predicate — it previously decremented `pagination.total` unconditionally for *any* deleted task in the workspace, even ones that never matched the current view's filters (wrong category, wrong status) and so were never counted in that total. Same bug class, not explicitly named in the ticket, but a natural low-risk extension caught while touching the same handler.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 124/124 passing (no regression)
- [x] Standalone logic simulation, 11 scenarios: all TM-8861 regression guards (unarchive-insert, archive-evict-any-page) still pass, plus new coverage (insert skipped off page 1, insert skipped during active search, category-match/mismatch on both insert and evict, `selectedCategory === -1` treated as "no filter", the `deleted` branch's new filter-aware decrement)
- [ ] QA: same caveat as always for this handler — no component test harness for Vue SFCs in this repo; live cross-tab verification would need multiple browser sessions with search/category filters + pagination set up differently per tab