### PR TITLE
fix: resolve task id from all URL param shapes on hard refresh

### DIFF
--- a/src/pages/NewForm.vue
+++ b/src/pages/NewForm.vue
@@ -244,7 +244,8 @@
 			modalTaskId.value ||
 			route.params.id ||
 			route.params.task_id ||
-			route.params.taskId;
+			route.params.taskId ||
+			route.params.task_number;
 		return id ? Number(id) : undefined;
 	});
 	const statuses = ref<Status[]>();


### PR DESCRIPTION
## Summary
- **Urgent prod bug**: opening a task's modal, then hard-refreshing (or loading the URL directly at `/{workspace}/{categoryCode}/{taskId}` or `/{workspace}/tasks/{taskId}`), lost the task entirely — the form rendered empty/in "create" mode instead of the real task.
- Root cause: `NewForm.vue`'s `taskId` computed already fell back through `route.params.id` / `task_id` / `taskId`, but never checked `route.params.task_number` — the exact param name Vue Router binds for the `/:workspace_code/:category_code/:task_number` route in `src/router/routes.js`. The modal-open path only "worked" because it sets the URL via `history.replaceState` *after* the component already mounted from store state (`setCurrentTaskIdForModal`) — route params are never consulted there. A hard refresh mounts fresh and has nothing but the URL to go on.
- `generateTaskUrl()` (`src/utils/url.ts`) always writes the real numeric task id into that URL slot regardless of the param's name, so this is a one-line param-name fix, not an id-resolution problem.

## Test plan
- [x] `npm test` — 124/124 pass
- [x] `npm run build` — succeeds
- [x] Verified live against the stage backend: created a real task in a real category, hard-loaded both `/{workspace}/{categoryCode}/{taskId}` and `/{workspace}/tasks/{taskId}` directly (fresh browser session, token seeded via localStorage to simulate a real hard refresh) — both now render the full task view (title, category, timer, comments) instead of an empty create-task form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)