### PR TITLE
feat: user theme selection (17 palettes + canonical light/dark)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,27 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
 	<head>
 		<meta charset="utf-8" />
+		<script>
+			(function () {
+				try {
+					var DARK = { dracula:1, nord:1, 'one-dark':1, monokai:1, 'solarized-dark':1, 'gruvbox-dark':1, 'tokyo-night':1, 'github-dark':1, 'night-owl':1, cobalt2:1, palenight:1, 'ayu-dark':1, 'catppuccin-mocha':1, 'synthwave-84':1, oled:1, colorblind:1 };
+					var html = document.documentElement;
+					var theme = localStorage.getItem('theme');
+					var cs = localStorage.getItem('colorScheme');
+					var dark;
+					if (theme && theme !== 'default' && (theme in DARK || theme === 'github-light')) {
+						html.classList.add('theme-' + theme);
+						dark = !!DARK[theme];
+					} else if (cs === 'dark' || cs === 'default') {
+						dark = cs === 'dark';
+					} else {
+						dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+					}
+					if (dark) html.classList.add('dark'); else html.classList.remove('dark');
+				} catch (e) {}
+			})();
+		</script>
 		<meta content="IE=edge" http-equiv="X-UA-Compatible" />
 		<meta content="width=device-width,initial-scale=1.0,viewport-fit=cover" name="viewport" />
 		<!-- CHANGES: Optimized font loading for better LCP -->

--- a/src/actions/tmgr/user.ts
+++ b/src/actions/tmgr/user.ts
@@ -1,6 +1,9 @@
 import $axios from '@/plugins/axios';
 import store from '@/store';
 import { FormSetting, Setting } from '@/actions/tmgr/settings';
+import { pickThemeFromSettings } from '@/theme/reconcile';
+
+export { pickThemeFromSettings };
 
 export interface User {
 	id: number;
@@ -16,6 +19,11 @@ export const getUser = async () => {
 	} = await $axios.get('user');
 
 	store.commit('setUser', data);
+
+	const picked = pickThemeFromSettings(data?.settings);
+	if (picked.theme !== undefined) store.commit('setTheme', picked.theme);
+	if (picked.colorScheme !== undefined)
+		store.commit('setColorScheme', picked.colorScheme);
 
 	return data;
 };
@@ -70,4 +78,20 @@ export const updateUserSettingsV2 = async (payload: UserSettings) => {
 	} = await $axios.put('v2/user/settings', payload);
 
 	return data;
+};
+
+export const persistThemeSettings = async (
+	theme: string,
+	colorScheme: string,
+) => {
+	const current = Array.isArray(store.state.user?.settings)
+		? store.state.user.settings
+		: [];
+	const payload = current.map((s: any) => {
+		if (s.key === 'theme') return { id: s.id, value: theme };
+		if (s.key === 'colorScheme') return { id: s.id, value: colorScheme };
+		return { id: s.id, value: s.value };
+	});
+	const updatedUser = await updateUserSettingsV2(payload);
+	store.commit('setUser', updatedUser);
 };

--- a/src/components/general/CustomSidebar.vue
+++ b/src/components/general/CustomSidebar.vue
@@ -42,6 +42,7 @@
 		LogOut,
 		SquareKanban,
 		Plus,
+		Palette,
 		Settings2,
 		Inbox,
 		Package,
@@ -662,6 +663,13 @@
 										>
 											<Sliders />
 											Feature Settings
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											@click="$router.push('/settings?tab=theme')"
+											class="cursor-pointer"
+										>
+											<Palette />
+											Theme
 										</DropdownMenuItem>
 										<DropdownMenuItem>
 											<DarkMode />

--- a/src/components/general/DarkMode.vue
+++ b/src/components/general/DarkMode.vue
@@ -3,18 +3,22 @@
 	import store from '@/store';
 	import { computed } from 'vue';
 
+	const isDefaultTheme = computed(
+		() => (store.state.theme || 'default') === 'default',
+	);
 	const switchOn = computed({
 		get() {
 			return store.state.colorScheme === 'dark';
 		},
 		set(value) {
+			if (!isDefaultTheme.value) return;
 			store.commit('setColorScheme', value ? 'dark' : 'default');
 		},
 	});
 </script>
 
 <template>
-	<a href="#" @click="switchOn = !switchOn">
+	<a v-if="isDefaultTheme" href="#" @click="switchOn = !switchOn">
 		<div v-if="switchOn" class="flex">
 			<Sun class="size-4" />
 			<span class="ml-2">Light mode</span>

--- a/src/components/general/ThemePicker.vue
+++ b/src/components/general/ThemePicker.vue
@@ -1,197 +1,212 @@
 <template>
-	<div class="space-y-5">
-		<div class="flex flex-wrap gap-6">
-			<button
-				v-for="t in cards"
-				:key="t.id"
-				type="button"
-				class="w-[360px] max-w-full rounded-xl border p-3 text-left align-top transition-transform hover:-translate-y-0.5"
+	<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+		<button
+			v-for="t in cards"
+			:key="t.id"
+			type="button"
+			class="w-full rounded-xl border p-3 text-left align-top transition-transform hover:-translate-y-0.5"
+			:style="{
+				background: t.tokens.bg,
+				borderColor: selected === t.id ? t.tokens.brand : t.tokens.border,
+				boxShadow: selected === t.id ? '0 0 0 2px ' + t.tokens.brand : 'none',
+			}"
+			@click="choose(t.id)"
+		>
+			<!-- name + tag -->
+			<div class="mb-2 flex items-center gap-2">
+				<span
+					class="inline-block h-2.5 w-2.5 rounded-full"
+					:style="{ background: t.tokens.brand }"
+				></span>
+				<span
+					class="text-[13px] font-semibold"
+					:style="{ color: t.tokens.text }"
+					>{{ t.name }}</span
+				>
+				<span
+					class="font-mono text-[9px] uppercase tracking-wide"
+					:style="{ color: t.tokens.muted }"
+					>{{ t.tag }}</span
+				>
+				<span
+					v-if="selected === t.id"
+					class="ml-auto rounded-full px-1.5 py-0.5 text-[9px] font-semibold"
+					:style="{ background: t.tokens.brand, color: t.tokens.onAccent }"
+					>active</span
+				>
+			</div>
+
+			<!-- swatches -->
+			<div class="mb-2 flex gap-1">
+				<span
+					v-for="(c, i) in [
+						t.tokens.bg,
+						t.tokens.surface,
+						t.tokens.border,
+						t.tokens.brand,
+						t.tokens.timer,
+					]"
+					:key="i"
+					class="h-3 flex-1 rounded"
+					:style="{ background: c, outline: '1px solid ' + t.tokens.border }"
+				></span>
+			</div>
+
+			<!-- live mini preview (rendered at natural size, scaled to half) -->
+			<div
+				class="overflow-hidden rounded-lg"
 				:style="{
+					height: '132px',
+					border: '1px solid ' + t.tokens.border,
 					background: t.tokens.bg,
-					borderColor: selected === t.id ? t.tokens.brand : t.tokens.border,
-					boxShadow:
-						selected === t.id ? '0 0 0 2px ' + t.tokens.brand : 'none',
 				}"
-				@click="choose(t.id)"
 			>
-				<!-- name + tag -->
-				<div class="mb-3 flex items-center gap-2">
-					<span
-						class="inline-block h-3 w-3 rounded-full"
-						:style="{ background: t.tokens.brand }"
-					></span>
-					<span
-						class="text-[15px] font-semibold"
-						:style="{ color: t.tokens.text }"
-						>{{ t.name }}</span
-					>
-					<span
-						class="font-mono text-[11px] uppercase tracking-wide"
-						:style="{ color: t.tokens.muted }"
-						>{{ t.tag }}</span
-					>
-					<span
-						v-if="selected === t.id"
-						class="ml-auto rounded-full px-2 py-0.5 text-[10px] font-semibold"
-						:style="{ background: t.tokens.brand, color: t.tokens.onAccent }"
-						>active</span
-					>
-				</div>
-
-				<!-- swatches -->
-				<div class="mb-3 flex gap-1.5">
-					<span
-						v-for="(c, i) in [
-							t.tokens.bg,
-							t.tokens.surface,
-							t.tokens.border,
-							t.tokens.brand,
-							t.tokens.timer,
-						]"
-						:key="i"
-						class="h-4 flex-1 rounded"
-						:style="{
-							background: c,
-							outline: '1px solid ' + t.tokens.border,
-						}"
-					></span>
-				</div>
-
-				<!-- live mini preview -->
 				<div
-					class="flex h-[260px] overflow-hidden rounded-lg"
 					:style="{
-						border: '1px solid ' + t.tokens.border,
-						background: t.tokens.bg,
+						transform: 'scale(0.5)',
+						transformOrigin: 'top left',
+						width: '200%',
 					}"
 				>
-					<!-- icon rail -->
-					<div
-						class="flex w-10 flex-col items-center gap-3 py-3"
-						:style="{
-							background: t.tokens.bg,
-							borderRight: '1px solid ' + t.tokens.border,
-						}"
-					>
-						<span
-							class="flex h-5 w-5 items-center justify-center rounded text-[11px] font-bold"
-							:style="{ background: t.tokens.brand, color: t.tokens.onAccent }"
-							>Y</span
-						>
-						<span
-							class="flex h-4 w-4 items-center justify-center rounded text-[10px]"
-							:style="{ background: t.tokens.raised, color: t.tokens.text }"
-							>▦</span
-						>
-						<span class="text-[11px]" :style="{ color: t.tokens.muted }">☰</span>
-						<span class="text-[11px]" :style="{ color: t.tokens.muted }">▥</span>
-						<span
-							class="mt-auto flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold"
-							:style="{ background: t.tokens.raised, color: t.tokens.muted }"
-							>Y</span
-						>
-					</div>
-
-					<!-- main -->
-					<div class="flex-1 overflow-hidden px-3 py-2.5">
+					<div class="flex h-[264px]" :style="{ background: t.tokens.bg }">
+						<!-- icon rail -->
 						<div
-							class="mb-2 font-mono text-[9px]"
-							:style="{ color: t.tokens.muted }"
-						>
-							TMGR.DEV &nbsp;›&nbsp; Tasks (1955)
-						</div>
-						<div
-							class="mb-2.5 text-center text-[17px] font-bold"
-							:style="{ color: t.tokens.text }"
-						>
-							14618 hours 16 min
-						</div>
-						<div class="mb-2.5 flex gap-1.5">
-							<div
-								class="flex-1 rounded-md px-2.5 py-1.5 text-[11px]"
-								:style="{
-									background: t.tokens.surface,
-									border: '1px solid ' + t.tokens.border,
-									color: t.tokens.muted,
-								}"
-							>
-								search task
-							</div>
-							<div
-								class="flex h-7 w-7 items-center justify-center rounded-md text-[11px]"
-								:style="{
-									background: t.tokens.surface,
-									border: '1px solid ' + t.tokens.border,
-									color: t.tokens.muted,
-								}"
-							>
-								⋮
-							</div>
-						</div>
-						<div
-							v-for="row in previewRows"
-							:key="row.date"
-							class="mb-1.5 rounded-lg px-2.5 py-2"
+							class="flex w-10 flex-col items-center gap-3 py-3"
 							:style="{
-								background: t.tokens.surface,
-								border: '1px solid ' + t.tokens.border,
+								background: t.tokens.bg,
+								borderRight: '1px solid ' + t.tokens.border,
 							}"
 						>
 							<span
-								class="mb-1.5 inline-block rounded px-1.5 py-0.5 font-mono text-[8px] tracking-wide"
-								:style="{ background: t.tokens.raised, color: t.tokens.muted }"
-								>CURRENT.PROJECT</span
+								class="flex h-5 w-5 items-center justify-center rounded text-[11px] font-bold"
+								:style="{
+									background: t.tokens.brand,
+									color: t.tokens.onAccent,
+								}"
+								>Y</span
 							>
+							<span
+								class="flex h-4 w-4 items-center justify-center rounded text-[10px]"
+								:style="{ background: t.tokens.raised, color: t.tokens.text }"
+								>▦</span
+							>
+							<span class="text-[11px]" :style="{ color: t.tokens.muted }"
+								>☰</span
+							>
+							<span class="text-[11px]" :style="{ color: t.tokens.muted }"
+								>▥</span
+							>
+							<span
+								class="mt-auto flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold"
+								:style="{ background: t.tokens.raised, color: t.tokens.muted }"
+								>Y</span
+							>
+						</div>
+
+						<!-- main -->
+						<div class="flex-1 overflow-hidden px-3 py-2.5">
 							<div
-								class="mb-1.5 font-mono text-[13px]"
+								class="mb-2 font-mono text-[9px]"
+								:style="{ color: t.tokens.muted }"
+							>
+								TMGR.DEV &nbsp;›&nbsp; Tasks (1955)
+							</div>
+							<div
+								class="mb-2.5 text-center text-[17px] font-bold"
 								:style="{ color: t.tokens.text }"
 							>
-								{{ row.date }}
+								14618 hours 16 min
 							</div>
-							<div class="flex items-center gap-1.5">
-								<span class="text-[11px]" :style="{ color: t.tokens.timer }"
-									>◷</span
-								>
-								<span
-									class="text-[12px] font-medium"
-									:style="{ color: t.tokens.text }"
-									>{{ row.time }}</span
-								>
-								<span
-									class="flex h-4 w-4 items-center justify-center rounded text-[9px]"
+							<div class="mb-2.5 flex gap-1.5">
+								<div
+									class="flex-1 rounded-md px-2.5 py-1.5 text-[11px]"
 									:style="{
-										background: t.tokens.timer,
-										color: t.tokens.onAccent,
+										background: t.tokens.surface,
+										border: '1px solid ' + t.tokens.border,
+										color: t.tokens.muted,
 									}"
-									>▶</span
 								>
+									search task
+								</div>
+								<div
+									class="flex h-7 w-7 items-center justify-center rounded-md text-[11px]"
+									:style="{
+										background: t.tokens.surface,
+										border: '1px solid ' + t.tokens.border,
+										color: t.tokens.muted,
+									}"
+								>
+									⋮
+								</div>
+							</div>
+							<div
+								v-for="row in previewRows"
+								:key="row.date"
+								class="mb-1.5 rounded-lg px-2.5 py-2"
+								:style="{
+									background: t.tokens.surface,
+									border: '1px solid ' + t.tokens.border,
+								}"
+							>
+								<span
+									class="mb-1.5 inline-block rounded px-1.5 py-0.5 font-mono text-[8px] tracking-wide"
+									:style="{
+										background: t.tokens.raised,
+										color: t.tokens.muted,
+									}"
+									>CURRENT.PROJECT</span
+								>
+								<div
+									class="mb-1.5 font-mono text-[13px]"
+									:style="{ color: t.tokens.text }"
+								>
+									{{ row.date }}
+								</div>
+								<div class="flex items-center gap-1.5">
+									<span class="text-[11px]" :style="{ color: t.tokens.timer }"
+										>◷</span
+									>
+									<span
+										class="text-[12px] font-medium"
+										:style="{ color: t.tokens.text }"
+										>{{ row.time }}</span
+									>
+									<span
+										class="flex h-4 w-4 items-center justify-center rounded text-[9px]"
+										:style="{
+											background: t.tokens.timer,
+											color: t.tokens.onAccent,
+										}"
+										>▶</span
+									>
+								</div>
 							</div>
 						</div>
 					</div>
 				</div>
+			</div>
 
-				<!-- default light/dark toggle -->
-				<div
-					v-if="t.id === 'default'"
-					class="mt-3 flex items-center gap-2"
-					@click.stop
+			<!-- default light/dark toggle -->
+			<div
+				v-if="t.id === 'default'"
+				class="mt-2 flex items-center gap-2"
+				@click.stop
+			>
+				<span class="text-[11px]" :style="{ color: t.tokens.muted }">Mode:</span>
+				<span
+					class="cursor-pointer rounded-full px-2 py-0.5 text-[11px]"
+					:style="modeStyle('default', t.tokens)"
+					@click="chooseScheme('default')"
+					>Light</span
 				>
-					<span class="text-xs" :style="{ color: t.tokens.muted }">Mode:</span>
-					<span
-						class="cursor-pointer rounded-full px-2.5 py-1 text-xs"
-						:style="modeStyle('default', t.tokens)"
-						@click="chooseScheme('default')"
-						>Light</span
-					>
-					<span
-						class="cursor-pointer rounded-full px-2.5 py-1 text-xs"
-						:style="modeStyle('dark', t.tokens)"
-						@click="chooseScheme('dark')"
-						>Dark</span
-					>
-				</div>
-			</button>
-		</div>
+				<span
+					class="cursor-pointer rounded-full px-2 py-0.5 text-[11px]"
+					:style="modeStyle('dark', t.tokens)"
+					@click="chooseScheme('dark')"
+					>Dark</span
+				>
+			</div>
+		</button>
 	</div>
 </template>
 
@@ -258,7 +273,10 @@
 			const selected = computed(() => store.state.theme || 'default');
 			const colorScheme = computed(() => store.state.colorScheme || 'default');
 
-			function modeStyle(mode: string, tokens: { brand: string; onAccent: string; muted: string; border: string }) {
+			function modeStyle(
+				mode: string,
+				tokens: { brand: string; onAccent: string; muted: string; border: string },
+			) {
 				const on = colorScheme.value === mode;
 				return {
 					background: on ? tokens.brand : 'transparent',

--- a/src/components/general/ThemePicker.vue
+++ b/src/components/general/ThemePicker.vue
@@ -1,0 +1,115 @@
+<template>
+	<div class="space-y-4">
+		<div class="flex flex-wrap gap-3">
+			<button
+				type="button"
+				class="w-44 rounded-lg border border-gray-200 p-3 text-left transition-colors dark:border-gray-700"
+				:class="
+					selected === 'default'
+						? 'ring-2 ring-blue-500'
+						: 'hover:bg-gray-50 dark:hover:bg-gray-800'
+				"
+				@click="choose('default')"
+			>
+				<div class="mb-2 flex gap-1">
+					<span class="h-5 flex-1 rounded bg-white border border-gray-200"></span>
+					<span class="h-5 flex-1 rounded bg-gray-800"></span>
+					<span class="h-5 flex-1 rounded bg-blue-500"></span>
+				</div>
+				<div class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+					Default
+				</div>
+				<div class="text-xs text-gray-500 dark:text-gray-400">
+					light / dark toggle
+				</div>
+			</button>
+
+			<button
+				v-for="t in registry"
+				:key="t.id"
+				type="button"
+				class="w-44 rounded-lg border p-3 text-left transition-transform hover:-translate-y-0.5"
+				:class="selected === t.id ? 'ring-2 ring-blue-500' : ''"
+				:style="{ background: t.tokens.bg, borderColor: t.tokens.border }"
+				@click="choose(t.id)"
+			>
+				<div class="mb-2 flex gap-1">
+					<span
+						class="h-5 flex-1 rounded"
+						:style="{ background: t.tokens.surface }"
+					></span>
+					<span
+						class="h-5 flex-1 rounded"
+						:style="{ background: t.tokens.border }"
+					></span>
+					<span
+						class="h-5 flex-1 rounded"
+						:style="{ background: t.tokens.brand }"
+					></span>
+					<span
+						class="h-5 flex-1 rounded"
+						:style="{ background: t.tokens.timer }"
+					></span>
+				</div>
+				<div class="text-sm font-semibold" :style="{ color: t.tokens.text }">
+					{{ t.name }}
+				</div>
+			</button>
+		</div>
+
+		<div v-if="selected === 'default'" class="flex items-center gap-3">
+			<span class="text-sm text-gray-600 dark:text-gray-300">Mode:</span>
+			<button
+				type="button"
+				class="rounded-full border border-gray-200 px-3 py-1 text-sm dark:border-gray-700"
+				:class="colorScheme === 'default' ? 'bg-blue-500 text-white' : ''"
+				@click="chooseScheme('default')"
+			>
+				Light
+			</button>
+			<button
+				type="button"
+				class="rounded-full border border-gray-200 px-3 py-1 text-sm dark:border-gray-700"
+				:class="colorScheme === 'dark' ? 'bg-blue-500 text-white' : ''"
+				@click="chooseScheme('dark')"
+			>
+				Dark
+			</button>
+		</div>
+	</div>
+</template>
+
+<script lang="ts">
+	import { defineComponent, computed } from 'vue';
+	import store from '@/store';
+	import { THEME_REGISTRY } from '@/theme/registry';
+	import { persistThemeSettings } from '@/actions/tmgr/user';
+
+	export default defineComponent({
+		name: 'ThemePicker',
+		setup() {
+			const registry = THEME_REGISTRY;
+			const selected = computed(() => store.state.theme || 'default');
+			const colorScheme = computed(() => store.state.colorScheme || 'default');
+
+			async function persist() {
+				try {
+					if (store.getters.isLoggedIn) {
+						await persistThemeSettings(store.state.theme, store.state.colorScheme);
+					}
+				} catch (e) {
+					console.error('Failed to persist theme', e);
+				}
+			}
+			async function choose(id: string) {
+				store.commit('setTheme', id);
+				await persist();
+			}
+			async function chooseScheme(scheme: string) {
+				store.commit('setColorScheme', scheme);
+				await persist();
+			}
+			return { registry, selected, colorScheme, choose, chooseScheme };
+		},
+	});
+</script>

--- a/src/components/general/ThemePicker.vue
+++ b/src/components/general/ThemePicker.vue
@@ -1,79 +1,195 @@
 <template>
-	<div class="space-y-4">
-		<div class="flex flex-wrap gap-3">
+	<div class="space-y-5">
+		<div class="flex flex-wrap gap-6">
 			<button
-				type="button"
-				class="w-44 rounded-lg border border-gray-200 p-3 text-left transition-colors dark:border-gray-700"
-				:class="
-					selected === 'default'
-						? 'ring-2 ring-blue-500'
-						: 'hover:bg-gray-50 dark:hover:bg-gray-800'
-				"
-				@click="choose('default')"
-			>
-				<div class="mb-2 flex gap-1">
-					<span class="h-5 flex-1 rounded bg-white border border-gray-200"></span>
-					<span class="h-5 flex-1 rounded bg-gray-800"></span>
-					<span class="h-5 flex-1 rounded bg-blue-500"></span>
-				</div>
-				<div class="text-sm font-semibold text-gray-900 dark:text-gray-100">
-					Default
-				</div>
-				<div class="text-xs text-gray-500 dark:text-gray-400">
-					light / dark toggle
-				</div>
-			</button>
-
-			<button
-				v-for="t in registry"
+				v-for="t in cards"
 				:key="t.id"
 				type="button"
-				class="w-44 rounded-lg border p-3 text-left transition-transform hover:-translate-y-0.5"
-				:class="selected === t.id ? 'ring-2 ring-blue-500' : ''"
-				:style="{ background: t.tokens.bg, borderColor: t.tokens.border }"
+				class="w-[360px] max-w-full rounded-xl border p-3 text-left align-top transition-transform hover:-translate-y-0.5"
+				:style="{
+					background: t.tokens.bg,
+					borderColor: selected === t.id ? t.tokens.brand : t.tokens.border,
+					boxShadow:
+						selected === t.id ? '0 0 0 2px ' + t.tokens.brand : 'none',
+				}"
 				@click="choose(t.id)"
 			>
-				<div class="mb-2 flex gap-1">
+				<!-- name + tag -->
+				<div class="mb-3 flex items-center gap-2">
 					<span
-						class="h-5 flex-1 rounded"
-						:style="{ background: t.tokens.surface }"
-					></span>
-					<span
-						class="h-5 flex-1 rounded"
-						:style="{ background: t.tokens.border }"
-					></span>
-					<span
-						class="h-5 flex-1 rounded"
+						class="inline-block h-3 w-3 rounded-full"
 						:style="{ background: t.tokens.brand }"
 					></span>
 					<span
-						class="h-5 flex-1 rounded"
-						:style="{ background: t.tokens.timer }"
+						class="text-[15px] font-semibold"
+						:style="{ color: t.tokens.text }"
+						>{{ t.name }}</span
+					>
+					<span
+						class="font-mono text-[11px] uppercase tracking-wide"
+						:style="{ color: t.tokens.muted }"
+						>{{ t.tag }}</span
+					>
+					<span
+						v-if="selected === t.id"
+						class="ml-auto rounded-full px-2 py-0.5 text-[10px] font-semibold"
+						:style="{ background: t.tokens.brand, color: t.tokens.onAccent }"
+						>active</span
+					>
+				</div>
+
+				<!-- swatches -->
+				<div class="mb-3 flex gap-1.5">
+					<span
+						v-for="(c, i) in [
+							t.tokens.bg,
+							t.tokens.surface,
+							t.tokens.border,
+							t.tokens.brand,
+							t.tokens.timer,
+						]"
+						:key="i"
+						class="h-4 flex-1 rounded"
+						:style="{
+							background: c,
+							outline: '1px solid ' + t.tokens.border,
+						}"
 					></span>
 				</div>
-				<div class="text-sm font-semibold" :style="{ color: t.tokens.text }">
-					{{ t.name }}
-				</div>
-			</button>
-		</div>
 
-		<div v-if="selected === 'default'" class="flex items-center gap-3">
-			<span class="text-sm text-gray-600 dark:text-gray-300">Mode:</span>
-			<button
-				type="button"
-				class="rounded-full border border-gray-200 px-3 py-1 text-sm dark:border-gray-700"
-				:class="colorScheme === 'default' ? 'bg-blue-500 text-white' : ''"
-				@click="chooseScheme('default')"
-			>
-				Light
-			</button>
-			<button
-				type="button"
-				class="rounded-full border border-gray-200 px-3 py-1 text-sm dark:border-gray-700"
-				:class="colorScheme === 'dark' ? 'bg-blue-500 text-white' : ''"
-				@click="chooseScheme('dark')"
-			>
-				Dark
+				<!-- live mini preview -->
+				<div
+					class="flex h-[260px] overflow-hidden rounded-lg"
+					:style="{
+						border: '1px solid ' + t.tokens.border,
+						background: t.tokens.bg,
+					}"
+				>
+					<!-- icon rail -->
+					<div
+						class="flex w-10 flex-col items-center gap-3 py-3"
+						:style="{
+							background: t.tokens.bg,
+							borderRight: '1px solid ' + t.tokens.border,
+						}"
+					>
+						<span
+							class="flex h-5 w-5 items-center justify-center rounded text-[11px] font-bold"
+							:style="{ background: t.tokens.brand, color: t.tokens.onAccent }"
+							>Y</span
+						>
+						<span
+							class="flex h-4 w-4 items-center justify-center rounded text-[10px]"
+							:style="{ background: t.tokens.raised, color: t.tokens.text }"
+							>▦</span
+						>
+						<span class="text-[11px]" :style="{ color: t.tokens.muted }">☰</span>
+						<span class="text-[11px]" :style="{ color: t.tokens.muted }">▥</span>
+						<span
+							class="mt-auto flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold"
+							:style="{ background: t.tokens.raised, color: t.tokens.muted }"
+							>Y</span
+						>
+					</div>
+
+					<!-- main -->
+					<div class="flex-1 overflow-hidden px-3 py-2.5">
+						<div
+							class="mb-2 font-mono text-[9px]"
+							:style="{ color: t.tokens.muted }"
+						>
+							TMGR.DEV &nbsp;›&nbsp; Tasks (1955)
+						</div>
+						<div
+							class="mb-2.5 text-center text-[17px] font-bold"
+							:style="{ color: t.tokens.text }"
+						>
+							14618 hours 16 min
+						</div>
+						<div class="mb-2.5 flex gap-1.5">
+							<div
+								class="flex-1 rounded-md px-2.5 py-1.5 text-[11px]"
+								:style="{
+									background: t.tokens.surface,
+									border: '1px solid ' + t.tokens.border,
+									color: t.tokens.muted,
+								}"
+							>
+								search task
+							</div>
+							<div
+								class="flex h-7 w-7 items-center justify-center rounded-md text-[11px]"
+								:style="{
+									background: t.tokens.surface,
+									border: '1px solid ' + t.tokens.border,
+									color: t.tokens.muted,
+								}"
+							>
+								⋮
+							</div>
+						</div>
+						<div
+							v-for="row in previewRows"
+							:key="row.date"
+							class="mb-1.5 rounded-lg px-2.5 py-2"
+							:style="{
+								background: t.tokens.surface,
+								border: '1px solid ' + t.tokens.border,
+							}"
+						>
+							<span
+								class="mb-1.5 inline-block rounded px-1.5 py-0.5 font-mono text-[8px] tracking-wide"
+								:style="{ background: t.tokens.raised, color: t.tokens.muted }"
+								>CURRENT.PROJECT</span
+							>
+							<div
+								class="mb-1.5 font-mono text-[13px]"
+								:style="{ color: t.tokens.text }"
+							>
+								{{ row.date }}
+							</div>
+							<div class="flex items-center gap-1.5">
+								<span class="text-[11px]" :style="{ color: t.tokens.timer }"
+									>◷</span
+								>
+								<span
+									class="text-[12px] font-medium"
+									:style="{ color: t.tokens.text }"
+									>{{ row.time }}</span
+								>
+								<span
+									class="flex h-4 w-4 items-center justify-center rounded text-[9px]"
+									:style="{
+										background: t.tokens.timer,
+										color: t.tokens.onAccent,
+									}"
+									>▶</span
+								>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- default light/dark toggle -->
+				<div
+					v-if="t.id === 'default'"
+					class="mt-3 flex items-center gap-2"
+					@click.stop
+				>
+					<span class="text-xs" :style="{ color: t.tokens.muted }">Mode:</span>
+					<span
+						class="cursor-pointer rounded-full px-2.5 py-1 text-xs"
+						:style="modeStyle('default', t.tokens)"
+						@click="chooseScheme('default')"
+						>Light</span
+					>
+					<span
+						class="cursor-pointer rounded-full px-2.5 py-1 text-xs"
+						:style="modeStyle('dark', t.tokens)"
+						@click="chooseScheme('dark')"
+						>Dark</span
+					>
+				</div>
 			</button>
 		</div>
 	</div>
@@ -82,15 +198,74 @@
 <script lang="ts">
 	import { defineComponent, computed } from 'vue';
 	import store from '@/store';
-	import { THEME_REGISTRY } from '@/theme/registry';
+	import { THEME_REGISTRY, ThemeDef } from '@/theme/registry';
 	import { persistThemeSettings } from '@/actions/tmgr/user';
+
+	const TAGS: Record<string, string> = {
+		default: 'canonical',
+		dracula: 'purple',
+		nord: 'frost',
+		'one-dark': 'atom',
+		monokai: 'classic',
+		'solarized-dark': 'muted',
+		'gruvbox-dark': 'retro',
+		'tokyo-night': 'night',
+		'github-dark': 'default',
+		'night-owl': 'deep',
+		cobalt2: 'blue',
+		palenight: 'material',
+		'ayu-dark': 'warm',
+		'catppuccin-mocha': 'pastel',
+		'synthwave-84': 'neon',
+		'github-light': 'light',
+		oled: 'true black',
+		colorblind: 'okabe-ito',
+	};
+
+	const DEFAULT_CARD = {
+		id: 'default',
+		name: 'Default',
+		tag: TAGS.default,
+		tokens: {
+			bg: 'var(--bg)',
+			surface: 'var(--bg-raised)',
+			raised: 'var(--bg-sunken)',
+			border: 'var(--line-strong-color)',
+			text: 'var(--fg)',
+			muted: 'var(--fg-muted)',
+			brand: 'var(--brand-color)',
+			timer: 'var(--timer-color, #30d158)',
+			onAccent: 'var(--brand-fg-color)',
+		},
+	};
 
 	export default defineComponent({
 		name: 'ThemePicker',
 		setup() {
-			const registry = THEME_REGISTRY;
+			const cards = computed(() => [
+				DEFAULT_CARD,
+				...THEME_REGISTRY.map((t: ThemeDef) => ({
+					id: t.id,
+					name: t.name,
+					tag: TAGS[t.id] || '',
+					tokens: t.tokens,
+				})),
+			]);
+			const previewRows = [
+				{ date: '2026-07-13', time: '8 hours 34 minutes' },
+				{ date: '2026-07-10', time: '14 hours 8 minutes' },
+			];
 			const selected = computed(() => store.state.theme || 'default');
 			const colorScheme = computed(() => store.state.colorScheme || 'default');
+
+			function modeStyle(mode: string, tokens: { brand: string; onAccent: string; muted: string; border: string }) {
+				const on = colorScheme.value === mode;
+				return {
+					background: on ? tokens.brand : 'transparent',
+					color: on ? tokens.onAccent : tokens.muted,
+					border: '1px solid ' + tokens.border,
+				};
+			}
 
 			async function persist() {
 				try {
@@ -109,7 +284,15 @@
 				store.commit('setColorScheme', scheme);
 				await persist();
 			}
-			return { registry, selected, colorScheme, choose, chooseScheme };
+			return {
+				cards,
+				previewRows,
+				selected,
+				colorScheme,
+				modeStyle,
+				choose,
+				chooseScheme,
+			};
 		},
 	});
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import router from '@/router';
 import alertPlugin from '@/alert';
 
 store.commit('setColorScheme', localStorage.getItem('colorScheme'));
+store.commit('setTheme', localStorage.getItem('theme') || 'default');
 
 const app = createApp(App);
 

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -44,6 +44,11 @@
 						</div>
 					</div>
 
+					<div v-if="isTheme" class="flex flex-col gap-3.5 p-4">
+						<h3 class="mb-4 text-lg font-bold">Theme</h3>
+						<ThemePicker />
+					</div>
+
 					<div
 						v-if="isWorkspaceSettings"
 						class="flex flex-col gap-3 p-4 md:w-1/2"
@@ -406,6 +411,7 @@
 	import TextField from '@/components/general/TextField.vue';
 	import Profile from '@/pages/Profile.vue';
 	import NotificationSettingsForm from '@/components/notifications/NotificationSettingsForm.vue';
+	import ThemePicker from '@/components/general/ThemePicker.vue';
 	import { generateLink, unlink } from '@/actions/tmgr/telegram';
 	import {
 		generateSmartDeviceToken,
@@ -434,6 +440,7 @@
 			Confirm,
 			CurrentWorkspace,
 			NotificationSettingsForm,
+			ThemePicker,
 		},
 		created() {
 			this.handleTabFromQuery();
@@ -447,6 +454,7 @@
 			isWorkspaceSettings: true,
 			isProfile: false,
 			isDevice: false,
+			isTheme: false,
 			telegramLink: null,
 			showToken: false,
 			tokenCopied: false,
@@ -552,6 +560,9 @@
 						case 'device':
 							this.showDeviceSettings();
 							break;
+						case 'theme':
+							this.showThemeSettings();
+							break;
 					}
 				}
 			},
@@ -561,6 +572,7 @@
 				this.isProfile = false;
 				this.isNotification = true;
 				this.isDevice = false;
+				this.isTheme = false;
 				this.updateQueryParam('notification');
 			},
 
@@ -569,6 +581,7 @@
 				this.isWorkspaceSettings = true;
 				this.isProfile = false;
 				this.isDevice = false;
+				this.isTheme = false;
 				this.updateQueryParam('workspace');
 			},
 
@@ -577,6 +590,7 @@
 				this.isWorkspaceSettings = false;
 				this.isProfile = true;
 				this.isDevice = false;
+				this.isTheme = false;
 				this.updateQueryParam('profile');
 			},
 
@@ -585,7 +599,17 @@
 				this.isWorkspaceSettings = false;
 				this.isProfile = false;
 				this.isDevice = true;
+				this.isTheme = false;
 				this.updateQueryParam('device');
+			},
+
+			showThemeSettings() {
+				this.isNotification = false;
+				this.isWorkspaceSettings = false;
+				this.isProfile = false;
+				this.isDevice = false;
+				this.isTheme = true;
+				this.updateQueryParam('theme');
 			},
 
 			updateQueryParam(tab) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import dailyRoutinesModule from '@/store/modules/dailyRoutines';
 import { createStore } from 'vuex';
 import { getWorkspaces } from '@/actions/tmgr/workspaces';
 import { requestCache } from '@/utils/requestCache';
+import { applyThemeToDocument } from '@/theme/applyTheme';
 
 const token = localStorage.getItem('token')
 	? JSON.parse(localStorage.getItem('token') || '')
@@ -22,6 +23,7 @@ const state = {
 	token: token,
 	user: {},
 	colorScheme: localStorage.getItem('colorScheme') || 'default',
+	theme: localStorage.getItem('theme') || 'default',
 	currentTaskIdForModal: null,
 	createTaskInProjectCategoryId: null,
 	taskStatusId: null,
@@ -168,13 +170,27 @@ const mutations = {
 		state.showCreatingTaskModal = true;
 	},
 	setColorScheme(state, colorScheme) {
-		if (colorScheme) {
-			state.userSettings.colorScheme = colorScheme;
-		}
-		state.colorScheme = colorScheme;
-		localStorage.setItem('colorScheme', colorScheme);
-		document.querySelector('html').className =
-			colorScheme === 'dark' ? 'dark' : '';
+		const normalized = colorScheme === 'dark' ? 'dark' : 'default';
+		state.userSettings.colorScheme = normalized;
+		state.colorScheme = normalized;
+		localStorage.setItem('colorScheme', normalized);
+		applyThemeToDocument(state.theme, normalized);
+	},
+	setTheme(state, theme) {
+		const normalized = theme || 'default';
+		state.theme = normalized;
+		localStorage.setItem('theme', normalized);
+		applyThemeToDocument(normalized, state.colorScheme);
+	},
+	setThemeToSystem(state) {
+		state.theme = 'default';
+		state.colorScheme =
+			typeof window !== 'undefined' &&
+			window.matchMedia &&
+			window.matchMedia('(prefers-color-scheme: dark)').matches
+				? 'dark'
+				: 'default';
+		applyThemeToDocument('default', state.colorScheme);
 	},
 	closeTaskModal(state) {
 		// Instead of using history.back() which can cause navigation issues,
@@ -253,6 +269,9 @@ const actions = {
 		Object.keys(localStorage)
 			.filter((key) => key.startsWith('pomo-enabled-'))
 			.forEach((key) => localStorage.removeItem(key));
+		localStorage.removeItem('theme');
+		localStorage.removeItem('colorScheme');
+		commit('setThemeToSystem');
 		requestCache.clear();
 	},
 

--- a/src/theme/applyTheme.ts
+++ b/src/theme/applyTheme.ts
@@ -1,0 +1,43 @@
+import { THEME_IS_DARK, DEFAULT_THEME, THEME_REGISTRY } from '@/theme/registry';
+import { buildPaletteCss } from '@/theme/paletteCss';
+
+export function computeThemeClasses(
+	theme: string | null | undefined,
+	colorScheme: string | null | undefined,
+	prefersDark: boolean,
+): { paletteClass: string | null; dark: boolean } {
+	const isKnownPalette =
+		!!theme && theme !== DEFAULT_THEME && theme in THEME_IS_DARK;
+	if (isKnownPalette) {
+		return { paletteClass: `theme-${theme}`, dark: THEME_IS_DARK[theme as string] };
+	}
+	const hasScheme = colorScheme === 'dark' || colorScheme === 'default';
+	const dark = hasScheme ? colorScheme === 'dark' : prefersDark;
+	return { paletteClass: null, dark };
+}
+
+export function ensurePaletteStyleInjected(doc: Document = document): void {
+	if (doc.getElementById('tmgr-theme-palettes')) return;
+	const style = doc.createElement('style');
+	style.id = 'tmgr-theme-palettes';
+	style.textContent = buildPaletteCss(THEME_REGISTRY);
+	doc.head.appendChild(style);
+}
+
+export function applyThemeToDocument(
+	theme: string | null | undefined,
+	colorScheme: string | null | undefined,
+	doc: Document = document,
+): void {
+	ensurePaletteStyleInjected(doc);
+	const prefersDark =
+		typeof doc.defaultView?.matchMedia === 'function' &&
+		doc.defaultView.matchMedia('(prefers-color-scheme: dark)').matches;
+	const { paletteClass, dark } = computeThemeClasses(theme, colorScheme, !!prefersDark);
+	const html = doc.documentElement;
+	Array.from(html.classList)
+		.filter((c) => c.startsWith('theme-'))
+		.forEach((c) => html.classList.remove(c));
+	if (paletteClass) html.classList.add(paletteClass);
+	html.classList.toggle('dark', dark);
+}

--- a/src/theme/paletteCss.ts
+++ b/src/theme/paletteCss.ts
@@ -1,11 +1,48 @@
 import { ThemeDef } from '@/theme/registry';
 
+function hexToHslTriplet(hex: string): string {
+	let h = hex.trim().replace('#', '');
+	if (h.length === 3) {
+		h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+	}
+	const r = parseInt(h.slice(0, 2), 16) / 255;
+	const g = parseInt(h.slice(2, 4), 16) / 255;
+	const b = parseInt(h.slice(4, 6), 16) / 255;
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	const l = (max + min) / 2;
+	let s = 0;
+	let hue = 0;
+	if (max !== min) {
+		const d = max - min;
+		s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+		if (max === r) {
+			hue = (g - b) / d + (g < b ? 6 : 0);
+		} else if (max === g) {
+			hue = (b - r) / d + 2;
+		} else {
+			hue = (r - g) / d + 4;
+		}
+		hue /= 6;
+	}
+	return `${Math.round(hue * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+}
+
 export function buildPaletteCss(registry: ThemeDef[]): string {
 	return registry
 		.map((t) => {
 			const k = t.tokens;
+			const bg = hexToHslTriplet(k.bg);
+			const surface = hexToHslTriplet(k.surface);
+			const raised = hexToHslTriplet(k.raised);
+			const border = hexToHslTriplet(k.border);
+			const text = hexToHslTriplet(k.text);
+			const muted = hexToHslTriplet(k.muted);
+			const brand = hexToHslTriplet(k.brand);
+			const onAccent = hexToHslTriplet(k.onAccent);
 			return (
 				`html.theme-${t.id}{` +
+				// design-token layer (surfaces, text, brand, status accents)
 				`--bg:${k.bg};--bg-raised:${k.surface};--bg-sunken:${k.bg};` +
 				`--bg-hover:${k.raised};--bg-active:${k.raised};` +
 				`--line-color:${k.border};--line-strong-color:${k.border};` +
@@ -14,6 +51,19 @@ export function buildPaletteCss(registry: ThemeDef[]): string {
 				`--brand-hover-color:${k.brand};--brand-ring-color:${k.brand};` +
 				`--timer-color:${k.timer};--on-accent-color:${k.onAccent};` +
 				`--tag-bg:${k.raised};--tag-fg:${k.muted};` +
+				// shadcn HSL layer (sidebar, cards, buttons, inputs, popovers, borders)
+				`--background:${bg};--foreground:${text};` +
+				`--card:${surface};--card-foreground:${text};` +
+				`--popover:${surface};--popover-foreground:${text};` +
+				`--primary:${brand};--primary-foreground:${onAccent};` +
+				`--secondary:${raised};--secondary-foreground:${text};` +
+				`--muted:${raised};--muted-foreground:${muted};` +
+				`--accent:${raised};--accent-foreground:${text};` +
+				`--border:${border};--input:${border};--ring:${brand};` +
+				`--sidebar-background:${surface};--sidebar-foreground:${text};` +
+				`--sidebar-primary:${brand};--sidebar-primary-foreground:${onAccent};` +
+				`--sidebar-accent:${raised};--sidebar-accent-foreground:${text};` +
+				`--sidebar-border:${border};--sidebar-ring:${brand};` +
 				`}`
 			);
 		})

--- a/src/theme/paletteCss.ts
+++ b/src/theme/paletteCss.ts
@@ -1,0 +1,21 @@
+import { ThemeDef } from '@/theme/registry';
+
+export function buildPaletteCss(registry: ThemeDef[]): string {
+	return registry
+		.map((t) => {
+			const k = t.tokens;
+			return (
+				`html.theme-${t.id}{` +
+				`--bg:${k.bg};--bg-raised:${k.surface};--bg-sunken:${k.bg};` +
+				`--bg-hover:${k.raised};--bg-active:${k.raised};` +
+				`--line-color:${k.border};--line-strong-color:${k.border};` +
+				`--fg:${k.text};--fg-muted:${k.muted};--fg-subtle:${k.muted};--fg-faint:${k.muted};` +
+				`--brand-color:${k.brand};--brand-bg-color:${k.raised};--brand-fg-color:${k.onAccent};` +
+				`--brand-hover-color:${k.brand};--brand-ring-color:${k.brand};` +
+				`--timer-color:${k.timer};--on-accent-color:${k.onAccent};` +
+				`--tag-bg:${k.raised};--tag-fg:${k.muted};` +
+				`}`
+			);
+		})
+		.join('\n');
+}

--- a/src/theme/reconcile.ts
+++ b/src/theme/reconcile.ts
@@ -1,0 +1,12 @@
+export function pickThemeFromSettings(
+	settings: Array<{ key: string; value: string | number }> | undefined,
+): { theme?: string; colorScheme?: string } {
+	const out: { theme?: string; colorScheme?: string } = {};
+	if (!Array.isArray(settings)) return out;
+	for (const s of settings) {
+		if (s.key === 'theme' && s.value != null) out.theme = String(s.value);
+		if (s.key === 'colorScheme' && s.value != null)
+			out.colorScheme = String(s.value);
+	}
+	return out;
+}

--- a/src/theme/registry.ts
+++ b/src/theme/registry.ts
@@ -1,0 +1,45 @@
+export interface ThemeTokens {
+	bg: string;
+	surface: string;
+	raised: string;
+	border: string;
+	text: string;
+	muted: string;
+	brand: string;
+	timer: string;
+	onAccent: string;
+}
+export interface ThemeDef {
+	id: string;
+	name: string;
+	isDark: boolean;
+	tokens: ThemeTokens;
+}
+
+export const DEFAULT_THEME = 'default';
+
+export const THEME_REGISTRY: ThemeDef[] = [
+	{ id: 'dracula', name: 'Dracula', isDark: true, tokens: { bg:'#282a36', surface:'#21222c', raised:'#343746', border:'#44475a', text:'#f8f8f2', muted:'#6272a4', brand:'#bd93f9', timer:'#50fa7b', onAccent:'#282a36' } },
+	{ id: 'nord', name: 'Nord', isDark: true, tokens: { bg:'#2e3440', surface:'#272c36', raised:'#3b4252', border:'#434c5e', text:'#eceff4', muted:'#7b88a1', brand:'#88c0d0', timer:'#a3be8c', onAccent:'#2e3440' } },
+	{ id: 'one-dark', name: 'One Dark', isDark: true, tokens: { bg:'#282c34', surface:'#21252b', raised:'#2c313a', border:'#3b4048', text:'#dcdfe4', muted:'#5c6370', brand:'#61afef', timer:'#98c379', onAccent:'#282c34' } },
+	{ id: 'monokai', name: 'Monokai', isDark: true, tokens: { bg:'#272822', surface:'#1e1f1c', raised:'#34352f', border:'#414339', text:'#f8f8f2', muted:'#75715e', brand:'#f92672', timer:'#a6e22e', onAccent:'#272822' } },
+	{ id: 'solarized-dark', name: 'Solarized Dark', isDark: true, tokens: { bg:'#002b36', surface:'#00252e', raised:'#073642', border:'#0f4a56', text:'#eee8d5', muted:'#5a7681', brand:'#268bd2', timer:'#859900', onAccent:'#002b36' } },
+	{ id: 'gruvbox-dark', name: 'Gruvbox Dark', isDark: true, tokens: { bg:'#282828', surface:'#1d2021', raised:'#3c3836', border:'#504945', text:'#ebdbb2', muted:'#928374', brand:'#fabd2f', timer:'#b8bb26', onAccent:'#282828' } },
+	{ id: 'tokyo-night', name: 'Tokyo Night', isDark: true, tokens: { bg:'#1a1b26', surface:'#16161e', raised:'#24283b', border:'#2f334d', text:'#c0caf5', muted:'#565f89', brand:'#7aa2f7', timer:'#9ece6a', onAccent:'#1a1b26' } },
+	{ id: 'github-dark', name: 'GitHub Dark', isDark: true, tokens: { bg:'#0d1117', surface:'#010409', raised:'#161b22', border:'#30363d', text:'#e6edf3', muted:'#7d8590', brand:'#58a6ff', timer:'#3fb950', onAccent:'#0d1117' } },
+	{ id: 'night-owl', name: 'Night Owl', isDark: true, tokens: { bg:'#011627', surface:'#010f1c', raised:'#0b2942', border:'#1d3b53', text:'#d6deeb', muted:'#637777', brand:'#82aaff', timer:'#22da6e', onAccent:'#011627' } },
+	{ id: 'cobalt2', name: 'Cobalt2', isDark: true, tokens: { bg:'#193549', surface:'#15232d', raised:'#1e415e', border:'#0d5289', text:'#ffffff', muted:'#7b93a8', brand:'#ffc600', timer:'#3ad900', onAccent:'#193549' } },
+	{ id: 'palenight', name: 'Palenight', isDark: true, tokens: { bg:'#292d3e', surface:'#232635', raised:'#333747', border:'#444a63', text:'#d2d6ec', muted:'#676e95', brand:'#c792ea', timer:'#c3e88d', onAccent:'#292d3e' } },
+	{ id: 'ayu-dark', name: 'Ayu Dark', isDark: true, tokens: { bg:'#0b0e14', surface:'#080a0f', raised:'#131721', border:'#1f2430', text:'#bfbdb6', muted:'#565b66', brand:'#ffb454', timer:'#7fd962', onAccent:'#0b0e14' } },
+	{ id: 'catppuccin-mocha', name: 'Catppuccin Mocha', isDark: true, tokens: { bg:'#1e1e2e', surface:'#181825', raised:'#313244', border:'#45475a', text:'#cdd6f4', muted:'#6c7086', brand:'#cba6f7', timer:'#a6e3a1', onAccent:'#1e1e2e' } },
+	{ id: 'synthwave-84', name: "Synthwave '84", isDark: true, tokens: { bg:'#262335', surface:'#1e1a2c', raised:'#34294f', border:'#463465', text:'#ffffff', muted:'#848bbd', brand:'#ff7edb', timer:'#72f1b8', onAccent:'#262335' } },
+	{ id: 'github-light', name: 'GitHub Light', isDark: false, tokens: { bg:'#ffffff', surface:'#f6f8fa', raised:'#eaeef2', border:'#d0d7de', text:'#1f2328', muted:'#656d76', brand:'#0969da', timer:'#1a7f37', onAccent:'#ffffff' } },
+	{ id: 'oled', name: 'Dark OLED', isDark: true, tokens: { bg:'#000000', surface:'#0a0a0a', raised:'#161616', border:'#242424', text:'#f5f5f5', muted:'#8a8a8a', brand:'#4d9fff', timer:'#30d158', onAccent:'#000000' } },
+	{ id: 'colorblind', name: 'Color Blind Friendly', isDark: true, tokens: { bg:'#1b1d21', surface:'#16181b', raised:'#26292e', border:'#363a40', text:'#f0f1f2', muted:'#9198a1', brand:'#56b4e9', timer:'#e69f00', onAccent:'#16181b' } },
+];
+
+export const THEME_MAP: Record<string, ThemeDef> =
+	THEME_REGISTRY.reduce((acc, t) => { acc[t.id] = t; return acc; }, {} as Record<string, ThemeDef>);
+
+export const THEME_IS_DARK: Record<string, boolean> =
+	THEME_REGISTRY.reduce((acc, t) => { acc[t.id] = t.isDark; return acc; }, {} as Record<string, boolean>);

--- a/tests/theme/applyTheme.test.ts
+++ b/tests/theme/applyTheme.test.ts
@@ -1,0 +1,23 @@
+import { computeThemeClasses } from '@/theme/applyTheme';
+
+test('default theme uses colorScheme', () => {
+	expect(computeThemeClasses('default', 'dark', false)).toEqual({ paletteClass: null, dark: true });
+	expect(computeThemeClasses('default', 'default', false)).toEqual({ paletteClass: null, dark: false });
+});
+
+test('known dark palette forces dark + palette class', () => {
+	expect(computeThemeClasses('dracula', 'default', false)).toEqual({ paletteClass: 'theme-dracula', dark: true });
+});
+
+test('light palette forces light', () => {
+	expect(computeThemeClasses('github-light', 'dark', true)).toEqual({ paletteClass: 'theme-github-light', dark: false });
+});
+
+test('unknown theme falls back to default + colorScheme', () => {
+	expect(computeThemeClasses('bogus', 'dark', false)).toEqual({ paletteClass: null, dark: true });
+});
+
+test('no stored prefs falls back to system', () => {
+	expect(computeThemeClasses(null, null, true)).toEqual({ paletteClass: null, dark: true });
+	expect(computeThemeClasses(undefined, undefined, false)).toEqual({ paletteClass: null, dark: false });
+});

--- a/tests/theme/paletteCss.test.ts
+++ b/tests/theme/paletteCss.test.ts
@@ -1,0 +1,11 @@
+import { buildPaletteCss } from '@/theme/paletteCss';
+import { THEME_REGISTRY } from '@/theme/registry';
+
+test('builds a rule per palette mapping bg and brand', () => {
+	const css = buildPaletteCss(THEME_REGISTRY);
+	expect(css).toContain('html.theme-dracula');
+	expect(css).toContain('--bg:#282a36');
+	expect(css).toContain('--brand-color:#bd93f9');
+	expect(css).toContain('--timer-color:#50fa7b');
+	expect((css.match(/html\.theme-/g) || []).length).toBe(THEME_REGISTRY.length);
+});

--- a/tests/theme/reconcile.test.ts
+++ b/tests/theme/reconcile.test.ts
@@ -1,0 +1,16 @@
+import { pickThemeFromSettings } from '@/theme/reconcile';
+
+test('extracts theme + colorScheme from settings array', () => {
+	expect(
+		pickThemeFromSettings([
+			{ key: 'current_workspace', value: 3 },
+			{ key: 'theme', value: 'nord' },
+			{ key: 'colorScheme', value: 'dark' },
+		]),
+	).toEqual({ theme: 'nord', colorScheme: 'dark' });
+});
+
+test('returns empty when absent', () => {
+	expect(pickThemeFromSettings([{ key: 'current_workspace', value: 3 }])).toEqual({});
+	expect(pickThemeFromSettings(undefined)).toEqual({});
+});

--- a/tests/theme/registry.test.ts
+++ b/tests/theme/registry.test.ts
@@ -1,0 +1,19 @@
+import { THEME_REGISTRY, THEME_MAP, THEME_IS_DARK, DEFAULT_THEME } from '@/theme/registry';
+
+test('registry has 17 palettes with complete tokens', () => {
+	expect(THEME_REGISTRY).toHaveLength(17);
+	for (const t of THEME_REGISTRY) {
+		expect(t.id).toMatch(/^[a-z0-9-]+$/);
+		expect(typeof t.isDark).toBe('boolean');
+		for (const k of ['bg', 'surface', 'raised', 'border', 'text', 'muted', 'brand', 'timer', 'onAccent'] as const) {
+			expect(t.tokens[k]).toMatch(/^#|^rgb|^oklch/i);
+		}
+	}
+});
+
+test('lookup maps are consistent', () => {
+	expect(THEME_MAP['dracula'].name).toBe('Dracula');
+	expect(THEME_IS_DARK['github-light']).toBe(false);
+	expect(THEME_IS_DARK['dracula']).toBe(true);
+	expect(DEFAULT_THEME).toBe('default');
+});


### PR DESCRIPTION
Adds a theme picker in Settings: **Default** (with its light/dark toggle) plus **17 editor palettes** (Dracula, Nord, One Dark, Monokai, Solarized Dark, Gruvbox Dark, Tokyo Night, GitHub Dark, Night Owl, Cobalt2, Palenight, Ayu Dark, Catppuccin Mocha, Synthwave '84, GitHub Light, Dark OLED, Color Blind Friendly).

## How it works
- A frontend **registry** (`src/theme/registry.ts`) holds each palette's 9 design tokens. `buildPaletteCss` injects them at runtime as `html.theme-<id> { --bg: … }` overrides of the existing design-token CSS variables.
- A **pure resolver** `computeThemeClasses(theme, colorScheme, prefersDark)` decides the `theme-<id>` class + `dark` flag; a thin DOM applier writes them to `<html>`.
- Vuex gains `theme` state + a `setTheme` mutation. `setColorScheme` is **refactored in place** (not renamed) to route through the same applier; `'default'` (light) / `'dark'` values are preserved.
- **Anti-FOUC**: an inline `<head>` script in `index.html` applies the stored/system theme before mount, and `main.ts` commits the stored theme on boot.
- **Persistence**: theme + colorScheme persist to the backend (cross-device) via `persistThemeSettings` and mirror to `localStorage`. After `getUser()`, backend values win and overwrite the mirror.
- **Logout** clears the `theme`/`colorScheme` mirror and falls back to `prefers-color-scheme`.
- The navbar quick light/dark toggle is hidden while a palette is active.

## Tests
Pure, node-env Jest suites: registry, `computeThemeClasses`, `buildPaletteCss`, `pickThemeFromSettings`. Full suite green (148 tests), `npm run build` succeeds.

## Known limitation
Palettes override the design-token layer (bg/surface/text/brand/status/timer), which covers the primary app surfaces. The **shadcn HSL layer** (`--background`, `--primary`, … in `_extensions.scss`) is **not** re-mapped per palette in this MR; shadcn `ui/` primitives follow the canonical light/dark values via the `dark` class. Full per-palette shadcn mapping is a follow-up.

## Graceful degradation
Without the backend MR (theme/colorScheme rows), `pickThemeFromSettings` returns `{}` and `persistThemeSettings` no-ops on missing ids; the localStorage mirror keeps the feature fully working locally. Part 2/2.