### PR TITLE
fix(TM-8911): native confirm() breaks board timer→In Progress status switch

### DIFF
--- a/src/components/tasks/TaskBoardCard.vue
+++ b/src/components/tasks/TaskBoardCard.vue
@@ -208,10 +208,19 @@
 			</span>
 		</div>
 	</div>
+
+	<Confirm
+		v-if="timerStatusConfirm"
+		title="Switch status?"
+		:body="timerStatusConfirm.message"
+		@onCancel="timerStatusConfirm = null"
+		@onOk="confirmTimerStatusSwitch"
+	/>
 </template>
 
 <script>
 	import Badge from '../general/Badge.vue';
+	import Confirm from '@/components/general/Confirm.vue';
 	import TimePreparationMixin from '@/mixins/TimePreparationMixin';
 	import TasksListMixin from '@/mixins/TasksListMixin';
 	import SetTooltipData from '@/mixins/SetTooltipData';
@@ -278,6 +287,7 @@
 		},
 		components: {
 			TaskTimeInfo,
+			Confirm,
 			ClockPlus,
 			FilePenLine,
 			Siren,
@@ -339,6 +349,7 @@
 				isHovered: false,
 				showAssigneePopover: false,
 				workspaceMembers: [],
+				timerStatusConfirm: null,
 			};
 		},
 		computed: {
@@ -591,22 +602,23 @@
 			if (taskStatus && taskStatus.type === 'default') {
 				const activeStatus = this.statuses.find((s) => s.type === 'active');
 				if (activeStatus) {
-					await this.$nextTick();
-					setTimeout(async () => {
-						const shouldSwitch = confirm(
-							`Task "${this.task.title}" is in backlog. Switch to "${activeStatus.name}" status?`,
-						);
-						if (shouldSwitch) {
-							try {
-								await updateTaskStatus(this.task.id, activeStatus.id);
-								this.task.status_id = activeStatus.id;
-								this.$store.commit('updateSingleTask', this.task);
-							} catch (e) {
-								console.error('Failed to update status:', e);
-							}
-						}
-					}, 0);
+					this.timerStatusConfirm = {
+						activeStatus,
+						message: `Task "${this.task.title}" is in backlog. Switch to "${activeStatus.name}" status?`,
+					};
 				}
+			}
+		},
+		async confirmTimerStatusSwitch() {
+			if (!this.timerStatusConfirm) return;
+			const { activeStatus } = this.timerStatusConfirm;
+			this.timerStatusConfirm = null;
+			try {
+				await updateTaskStatus(this.task.id, activeStatus.id);
+				this.task.status_id = activeStatus.id;
+				this.$store.commit('updateSingleTask', this.task);
+			} catch (e) {
+				console.error('Failed to update status:', e);
 			}
 		},
 		async handleStopTimer() {


### PR DESCRIPTION
## Summary
- `TaskBoardCard.vue`'s `handleStartTimer()` was the lone holdout among 4 timer-start call sites still using native `window.confirm()` for the "switch to In Progress?" backlog prompt — `TasksListComponent.vue`/`TaskForm.vue`/`NewForm.vue` all use the in-app `Confirm` modal.
- A native `confirm()` blocks the main thread and is easy for users to reflexively dismiss (Escape / click-away) without reading — looks exactly like "starting the timer doesn't change status" from the reporter's side, even though the code ran.
- Swapped it for the same `Confirm` component pattern already used elsewhere in the codebase. No change to the underlying gating logic (`status.type === 'default'` → offer switch to the `active`-type status).

Root-caused via repro: tmgr TM-8911. Backend confirmed clean (timer-start endpoint never touches status) — this is 100% a frontend gap, isolated to the Board view.

**Separate, not fixed here:** whether every workspace's initial/seeded task status actually has `type: 'default'` is a backend/product question, not this bug — flagged to PM separately. If a workspace seeds tasks into a non-`default`-type initial status (e.g. "To Do"), this confirm gate never fires at all, by design of the existing gating condition.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 148/148 passing
- [ ] QA: start timer on a Board-view backlog card, confirm the in-app modal (not a native browser dialog) appears and Yes/Cancel both behave correctly