### PR TITLE
fix(TM-8893): mobile-responsive Time/Duration in routine edit modal

### DIFF
--- a/src/components/dailyRoutine/EditRoutineModal.vue
+++ b/src/components/dailyRoutine/EditRoutineModal.vue
@@ -107,7 +107,7 @@
 						<!-- Time + Duration -->
 						<div
 							v-if="!(draft.frequency === 'NONE' && draft.unscheduled)"
-							class="grid grid-cols-2 gap-2.5"
+							class="grid grid-cols-1 gap-2.5 sm:grid-cols-2"
 						>
 							<ERSection label="Time">
 								<div class="flex items-center gap-1.5 rounded-card border border-line bg-surface-sunken px-3 py-2.5">


### PR DESCRIPTION
## Summary
- `EditRoutineModal.vue` ("New routine"/extended form) hardcoded Time+Duration into a fixed 2-column grid. On mobile the Duration cell (icon, number input, "min" label, 5 preset pills) had to squeeze into ~half of a ~300px-wide modal — this is what made the extended form feel "неудобная" per the ticket.
- Stack to a single column below `sm:`, consistent with the file's existing responsive convention (`sm:p-5`).

**Note on the other half of the report:** "Create button заходит за хуй пойми куда" (button goes off-screen) was a `100vh`-vs-actual-mobile-viewport clipping bug — already fixed in `990aa60` (2026-07-11, switched to `dvh`), predating this ticket's active work. Confirmed that fix is intact and on master; no further action needed there. This PR covers the remaining layout-cramping complaint.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 148/148 passing
- [ ] QA: open "New routine" on a narrow (≤640px) viewport, expand to a recurring frequency, confirm Time and Duration stack vertically and the Duration preset buttons aren't cramped/overflowing